### PR TITLE
feat: add ping command plugin

### DIFF
--- a/cmd/daz/main.go
+++ b/cmd/daz/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hildolfr/daz/internal/plugins/commands/games"
 	"github.com/hildolfr/daz/internal/plugins/commands/help"
 	"github.com/hildolfr/daz/internal/plugins/commands/insult"
+	"github.com/hildolfr/daz/internal/plugins/commands/ping"
 	"github.com/hildolfr/daz/internal/plugins/commands/quote"
 	"github.com/hildolfr/daz/internal/plugins/commands/random"
 	"github.com/hildolfr/daz/internal/plugins/commands/seen"
@@ -222,6 +223,7 @@ func run(coreConfig *core.Config, cfg *config.Config, healthPort int, startTime 
 		{"games", games.New()},
 		{"help", help.New()},
 		{"insult", insult.New()},
+		{"ping", ping.New()},
 		{"quote", quote.New()},
 		{"uptime", uptime.New()},
 		{"weather", weather.New()},
@@ -251,6 +253,7 @@ func run(coreConfig *core.Config, cfg *config.Config, healthPort int, startTime 
 	pluginConfigs["about"] = cfg.GetPluginConfig("about")
 	pluginConfigs["clap"] = cfg.GetPluginConfig("clap")
 	pluginConfigs["insult"] = cfg.GetPluginConfig("insult")
+	pluginConfigs["ping"] = cfg.GetPluginConfig("ping")
 	pluginConfigs["fortune"] = cfg.GetPluginConfig("fortune")
 	pluginConfigs["games"] = cfg.GetPluginConfig("games")
 	pluginConfigs["help"] = cfg.GetPluginConfig("help")

--- a/internal/plugins/commands/ping/plugin.go
+++ b/internal/plugins/commands/ping/plugin.go
@@ -1,0 +1,159 @@
+package ping
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/hildolfr/daz/internal/framework"
+	"github.com/hildolfr/daz/internal/logger"
+)
+
+type Plugin struct {
+	name     string
+	eventBus framework.EventBus
+	running  bool
+
+	mu     sync.RWMutex
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func New() framework.Plugin {
+	return &Plugin{name: "ping"}
+}
+
+func (p *Plugin) Init(_ json.RawMessage, bus framework.EventBus) error {
+	p.eventBus = bus
+	p.ctx, p.cancel = context.WithCancel(context.Background())
+	return nil
+}
+
+func (p *Plugin) Start() error {
+	p.mu.Lock()
+	if p.running {
+		p.mu.Unlock()
+		return fmt.Errorf("plugin already running")
+	}
+	p.running = true
+	p.mu.Unlock()
+
+	if err := p.eventBus.Subscribe("command.ping.execute", p.handleCommand); err != nil {
+		return fmt.Errorf("failed to subscribe to command.ping.execute: %w", err)
+	}
+
+	p.registerCommands()
+	logger.Debug(p.name, "Started")
+	return nil
+}
+
+func (p *Plugin) Stop() error {
+	p.mu.Lock()
+	if !p.running {
+		p.mu.Unlock()
+		return nil
+	}
+	p.running = false
+	p.mu.Unlock()
+
+	if p.cancel != nil {
+		p.cancel()
+	}
+
+	logger.Debug(p.name, "Stopped")
+	return nil
+}
+
+func (p *Plugin) HandleEvent(event framework.Event) error {
+	_ = event
+	return nil
+}
+
+func (p *Plugin) Status() framework.PluginStatus {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	state := "stopped"
+	if p.running {
+		state = "running"
+	}
+
+	return framework.PluginStatus{Name: p.name, State: state}
+}
+
+func (p *Plugin) Name() string {
+	return p.name
+}
+
+func (p *Plugin) registerCommands() {
+	regEvent := &framework.EventData{
+		PluginRequest: &framework.PluginRequest{
+			To:   "eventfilter",
+			From: p.name,
+			Type: "register",
+			Data: &framework.RequestData{
+				KeyValue: map[string]string{
+					"commands": "ping",
+					"min_rank": "0",
+				},
+			},
+		},
+	}
+
+	if err := p.eventBus.Broadcast("command.register", regEvent); err != nil {
+		logger.Error(p.name, "Failed to register commands: %v", err)
+	}
+}
+
+func (p *Plugin) handleCommand(event framework.Event) error {
+	dataEvent, ok := event.(*framework.DataEvent)
+	if !ok || dataEvent.Data == nil || dataEvent.Data.PluginRequest == nil {
+		return nil
+	}
+
+	req := dataEvent.Data.PluginRequest
+	if req.Data == nil || req.Data.Command == nil {
+		return nil
+	}
+
+	params := req.Data.Command.Params
+	username := params["username"]
+	channel := params["channel"]
+	isPM := params["is_pm"] == "true"
+
+	_ = p.sendResponse(username, channel, isPM, "pong")
+	return nil
+}
+
+func (p *Plugin) sendResponse(username, channel string, isPM bool, message string) error {
+	if isPM {
+		response := &framework.EventData{
+			PluginResponse: &framework.PluginResponse{
+				From:    p.name,
+				Success: true,
+				Data: &framework.ResponseData{
+					CommandResult: &framework.CommandResultData{
+						Success: true,
+						Output:  message,
+					},
+					KeyValue: map[string]string{
+						"username": username,
+						"channel":  channel,
+					},
+				},
+			},
+		}
+		return p.eventBus.Broadcast("plugin.response", response)
+	}
+
+	chat := &framework.EventData{
+		RawMessage: &framework.RawMessageData{
+			Message: message,
+			Channel: channel,
+		},
+	}
+	// Don't fail command if chat send fails.
+	_ = p.eventBus.Broadcast("cytube.send", chat)
+	return nil
+}

--- a/internal/plugins/commands/ping/plugin_test.go
+++ b/internal/plugins/commands/ping/plugin_test.go
@@ -1,0 +1,176 @@
+package ping
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hildolfr/daz/internal/framework"
+)
+
+type mockEventBus struct {
+	mu         sync.Mutex
+	broadcasts []broadcastCall
+}
+
+type broadcastCall struct {
+	eventType string
+	data      *framework.EventData
+}
+
+func (m *mockEventBus) Broadcast(eventType string, data *framework.EventData) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.broadcasts = append(m.broadcasts, broadcastCall{eventType: eventType, data: data})
+	return nil
+}
+
+func (m *mockEventBus) BroadcastWithMetadata(eventType string, data *framework.EventData, metadata *framework.EventMetadata) error {
+	_ = metadata
+	return m.Broadcast(eventType, data)
+}
+
+func (m *mockEventBus) Send(target string, eventType string, data *framework.EventData) error {
+	_ = target
+	_ = eventType
+	_ = data
+	return nil
+}
+
+func (m *mockEventBus) SendWithMetadata(target string, eventType string, data *framework.EventData, metadata *framework.EventMetadata) error {
+	_ = metadata
+	return m.Send(target, eventType, data)
+}
+
+func (m *mockEventBus) Request(ctx context.Context, target string, eventType string, data *framework.EventData, metadata *framework.EventMetadata) (*framework.EventData, error) {
+	_ = ctx
+	_ = target
+	_ = eventType
+	_ = data
+	_ = metadata
+	return nil, nil
+}
+
+func (m *mockEventBus) DeliverResponse(correlationID string, response *framework.EventData, err error) {
+	_ = correlationID
+	_ = response
+	_ = err
+}
+
+func (m *mockEventBus) Subscribe(eventType string, handler framework.EventHandler) error {
+	_ = eventType
+	_ = handler
+	return nil
+}
+
+func (m *mockEventBus) SubscribeWithTags(pattern string, handler framework.EventHandler, tags []string) error {
+	_ = pattern
+	_ = handler
+	_ = tags
+	return nil
+}
+
+func (m *mockEventBus) RegisterPlugin(name string, plugin framework.Plugin) error {
+	_ = name
+	_ = plugin
+	return nil
+}
+
+func (m *mockEventBus) UnregisterPlugin(name string) error {
+	_ = name
+	return nil
+}
+
+func (m *mockEventBus) GetDroppedEventCounts() map[string]int64 {
+	return map[string]int64{}
+}
+
+func (m *mockEventBus) GetDroppedEventCount(eventType string) int64 {
+	_ = eventType
+	return 0
+}
+
+// Satisfy any sql-related interfaces in older mocks (not used here).
+func (m *mockEventBus) QuerySync(ctx context.Context, sql string, params ...framework.SQLParam) (*sql.Rows, error) {
+	_ = ctx
+	_ = sql
+	_ = params
+	return nil, nil
+}
+
+func (m *mockEventBus) ExecSync(ctx context.Context, sql string, params ...framework.SQLParam) (sql.Result, error) {
+	_ = ctx
+	_ = sql
+	_ = params
+	return nil, nil
+}
+
+func TestPing_ChatResponse(t *testing.T) {
+	bus := &mockEventBus{}
+	p := New().(*Plugin)
+	if err := p.Init(nil, bus); err != nil {
+		t.Fatalf("Init error: %v", err)
+	}
+
+	event := &framework.DataEvent{EventType: "command.ping.execute", EventTime: time.Now(), Data: &framework.EventData{PluginRequest: &framework.PluginRequest{Data: &framework.RequestData{Command: &framework.CommandData{Params: map[string]string{
+		"username": "alice",
+		"channel":  "chan",
+		"is_pm":    "false",
+	}}}}}}
+
+	if err := p.handleCommand(event); err != nil {
+		t.Fatalf("handleCommand error: %v", err)
+	}
+
+	bus.mu.Lock()
+	defer bus.mu.Unlock()
+
+	var saw bool
+	for _, b := range bus.broadcasts {
+		if b.eventType == "cytube.send" && b.data != nil && b.data.RawMessage != nil {
+			if b.data.RawMessage.Message != "pong" {
+				t.Fatalf("got message %q want %q", b.data.RawMessage.Message, "pong")
+			}
+			saw = true
+		}
+	}
+	if !saw {
+		t.Fatalf("expected cytube.send broadcast")
+	}
+}
+
+func TestPing_PMResponse(t *testing.T) {
+	bus := &mockEventBus{}
+	p := New().(*Plugin)
+	if err := p.Init(nil, bus); err != nil {
+		t.Fatalf("Init error: %v", err)
+	}
+
+	event := &framework.DataEvent{EventType: "command.ping.execute", EventTime: time.Now(), Data: &framework.EventData{PluginRequest: &framework.PluginRequest{Data: &framework.RequestData{Command: &framework.CommandData{Params: map[string]string{
+		"username": "alice",
+		"channel":  "chan",
+		"is_pm":    "true",
+	}}}}}}
+
+	if err := p.handleCommand(event); err != nil {
+		t.Fatalf("handleCommand error: %v", err)
+	}
+
+	bus.mu.Lock()
+	defer bus.mu.Unlock()
+
+	var saw bool
+	for _, b := range bus.broadcasts {
+		if b.eventType == "plugin.response" && b.data != nil && b.data.PluginResponse != nil && b.data.PluginResponse.Data != nil && b.data.PluginResponse.Data.CommandResult != nil {
+			if b.data.PluginResponse.Data.CommandResult.Output != "pong" {
+				t.Fatalf("got output %q want %q", b.data.PluginResponse.Data.CommandResult.Output, "pong")
+			}
+			saw = true
+		}
+	}
+	if !saw {
+		t.Fatalf("expected plugin.response broadcast")
+	}
+}


### PR DESCRIPTION
## What
- Adds a new `ping` command plugin under `internal/plugins/commands/ping`.
- Registers `ping` via `eventfilter`.

## Behavior
- `!ping` replies with `pong`.
- Works for both channel messages and PM (returns a command result for PM).

## Notes
- Includes unit tests for both chat and PM paths.