### PR TITLE
feat: implement dynamic help command

### DIFF
--- a/internal/plugins/commands/about/plugin.go
+++ b/internal/plugins/commands/about/plugin.go
@@ -132,8 +132,9 @@ func (p *Plugin) registerCommand() {
 			Type: "register",
 			Data: &framework.RequestData{
 				KeyValue: map[string]string{
-					"commands": "about,version,info",
-					"min_rank": "0",
+					"commands":   "about,version,info",
+					"min_rank":   "0",
+					"admin_only": "true",
 				},
 			},
 		},

--- a/internal/plugins/commands/help/plugin_test.go
+++ b/internal/plugins/commands/help/plugin_test.go
@@ -251,8 +251,8 @@ func TestStartStop(t *testing.T) {
 	bus.mu.Lock()
 	subCount := len(bus.subscriptions)
 	bus.mu.Unlock()
-	if subCount != 1 {
-		t.Errorf("Expected 1 subscription, got %d", subCount)
+	if subCount != 2 {
+		t.Errorf("Expected 2 subscriptions, got %d", subCount)
 	}
 
 	// Check command registration

--- a/internal/plugins/commands/uptime/plugin.go
+++ b/internal/plugins/commands/uptime/plugin.go
@@ -108,8 +108,9 @@ func (p *Plugin) registerCommand() {
 			Type: "register",
 			Data: &framework.RequestData{
 				KeyValue: map[string]string{
-					"commands": "uptime,up",
-					"min_rank": "0",
+					"commands":   "uptime,up",
+					"min_rank":   "0",
+					"admin_only": "true",
 				},
 			},
 		},

--- a/internal/plugins/gallery/plugin.go
+++ b/internal/plugins/gallery/plugin.go
@@ -212,8 +212,9 @@ func (p *Plugin) registerCommands() error {
 			Type: "register",
 			Data: &framework.RequestData{
 				KeyValue: map[string]string{
-					"commands": "gallery,gallery_lock,gallery_unlock,gallery_check",
-					"min_rank": "0", // Allow all users, we'll check permissions in handler
+					"commands":   "gallery,gallery_lock,gallery_unlock,gallery_check",
+					"min_rank":   "0", // Allow all users, we'll check permissions in handler
+					"admin_only": "gallery_check",
 				},
 			},
 		},

--- a/internal/plugins/playlist/playlist.go
+++ b/internal/plugins/playlist/playlist.go
@@ -213,6 +213,12 @@ func (p *Plugin) registerCommand() error {
 				KeyValue: map[string]string{
 					"commands": "playlistadd,playlistdelete",
 					"min_rank": "0", // Allow all users, we'll check admin in handler
+					"admin_only": func() string {
+						if p.adminOnly {
+							return "true"
+						}
+						return ""
+					}(),
 				},
 			},
 		},


### PR DESCRIPTION
## What
- Implements a dynamic `help` command that reads from the eventfilter command registry.
- Provides per-command details: plugin name, min rank, and aliases.

## Behavior
- `!help` sends a PM-only list of available commands (filtered by user rank).
- `!help <command>` returns a detailed single-command line.
- Splits long lists into multiple PMs only when needed.

## Notes
- Uses the SQL-backed `daz_eventfilter_commands` registry to stay current as new commands are added.