### PR TITLE
fix: filter system quotes

### DIFF
--- a/internal/plugins/commands/quote/plugin.go
+++ b/internal/plugins/commands/quote/plugin.go
@@ -193,6 +193,10 @@ func (p *Plugin) handleCommand(event framework.Event) error {
 			return nil
 		}
 		target := sanitizeTarget(cmd.Args[0])
+		if isSystemUsername(target) {
+			p.sendResponse(req, fmt.Sprintf("No quote found for %s.", strings.TrimSpace(cmd.Args[0])))
+			return nil
+		}
 		logger.Debug(p.name, "Quote self-target check: target=%q bot=%q channel=%q", target, botUsername, channel)
 		if isSelfTarget(target, botUsername) {
 			p.sendResponse(req, "Nope. I won't quote myself.")
@@ -237,6 +241,8 @@ func (p *Plugin) getRandomQuote(ctx context.Context, channel, username, botUsern
 		  AND message IS NOT NULL
 		  AND LENGTH(TRIM(message)) > 0
 		  AND message NOT LIKE '!%'
+		  AND LOWER(username) NOT IN ('system', 'server', 'cytube')
+		  AND LENGTH(TRIM(username)) > 0
 	`
 
 	args := []interface{}{channel}
@@ -432,6 +438,20 @@ func isSelfTarget(target, botUsername string) bool {
 	}
 
 	return t == b
+}
+
+func isSystemUsername(username string) bool {
+	name := strings.ToLower(strings.TrimSpace(username))
+	if name == "" {
+		return true
+	}
+
+	switch name {
+	case "system", "server", "cytube":
+		return true
+	default:
+		return false
+	}
 }
 
 func formatSince(messageTime int64) string {

--- a/internal/plugins/commands/quote/plugin_test.go
+++ b/internal/plugins/commands/quote/plugin_test.go
@@ -191,6 +191,18 @@ func TestIsSelfTarget(t *testing.T) {
 	}
 }
 
+func TestIsSystemUsername(t *testing.T) {
+	if !isSystemUsername("System") {
+		t.Fatalf("expected System to be treated as system username")
+	}
+	if !isSystemUsername("server") {
+		t.Fatalf("expected server to be treated as system username")
+	}
+	if isSystemUsername("dazza") {
+		t.Fatalf("did not expect normal user to be treated as system username")
+	}
+}
+
 func TestSanitizeQuoteMessage(t *testing.T) {
 	raw := `<span class="quote">&gt;dip my nuts in ink </span>`
 	got := sanitizeQuoteMessage(raw)


### PR DESCRIPTION
## What
- Excludes system-style usernames from random quote selection.
- Blocks explicit quoting of system usernames.

## Behavior
- Random quotes skip usernames like System/Server/Cytube.
- `!quote system` returns no-quote response.

## Tests
- `go test ./internal/plugins/commands/quote`