### PR TITLE
fix: keep help output in one PM

### DIFF
--- a/internal/plugins/commands/help/plugin.go
+++ b/internal/plugins/commands/help/plugin.go
@@ -612,10 +612,16 @@ func splitMessages(header string, lines []string, maxLen int) []string {
 	}
 
 	header = strings.TrimSpace(header)
-	current := header
-	if current != "" {
-		current += "\n"
+	if header != "" {
+		header += "\n"
 	}
+
+	full := header + strings.Join(lines, "\n")
+	if len([]rune(full)) <= maxLen {
+		return []string{strings.TrimSpace(full)}
+	}
+
+	current := header
 
 	var messages []string
 	for _, line := range lines {


### PR DESCRIPTION
## What
- Attempts a single PM for the full help list.
- Falls back to splitting only when the message would exceed the limit.

## Tests
- `go test ./internal/plugins/commands/help`