### PR TITLE
feat(economy): implement economy api and sql ledger

### DIFF
--- a/cmd/daz/main.go
+++ b/cmd/daz/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/hildolfr/daz/internal/plugins/commands/tell"
 	"github.com/hildolfr/daz/internal/plugins/commands/uptime"
 	"github.com/hildolfr/daz/internal/plugins/commands/weather"
+	"github.com/hildolfr/daz/internal/plugins/economy"
 	"github.com/hildolfr/daz/internal/plugins/eventfilter"
 	"github.com/hildolfr/daz/internal/plugins/gallery"
 	"github.com/hildolfr/daz/internal/plugins/greeter"
@@ -217,6 +218,7 @@ func run(coreConfig *core.Config, cfg *config.Config, healthPort int, startTime 
 		{"usertracker", usertracker.New()},
 		{"mediatracker", mediatracker.New()},
 		{"analytics", analytics.New()},
+		{"economy", economy.New()},
 		{"greeter", greeter.New()},
 		{"gallery", gallery.New()},
 		{"about", about.New()},
@@ -265,6 +267,7 @@ func run(coreConfig *core.Config, cfg *config.Config, healthPort int, startTime 
 	pluginConfigs["quote"] = cfg.GetPluginConfig("quote")
 	pluginConfigs["uptime"] = cfg.GetPluginConfig("uptime")
 	pluginConfigs["tell"] = cfg.GetPluginConfig("tell")
+	pluginConfigs["economy"] = cfg.GetPluginConfig("economy")
 	pluginConfigs["greeter"] = cfg.GetPluginConfig("greeter")
 	pluginConfigs["weather"] = cfg.GetPluginConfig("weather")
 	pluginConfigs["random"] = cfg.GetPluginConfig("random")

--- a/config.json.example
+++ b/config.json.example
@@ -1,22 +1,35 @@
 {
-  "rooms": [
-    {
-      "enabled": true,
-      "name": "Example Room",
-      "server": "cytu.be",
-      "channel": "your_channel_name",
-      "username": "your_bot_username",
-      "password": "your_bot_password",
-      "reconnect_attempts": 5,
-      "reconnect_delay": 30
+  "core": {
+    "rooms": [
+      {
+        "id": "main",
+        "channel": "your_channel_name",
+        "username": "your_bot_username",
+        "password": "your_bot_password",
+        "enabled": true,
+        "reconnect_attempts": 10,
+        "cooldown_minutes": 30
+      }
+    ],
+    "database": {
+      "host": "localhost",
+      "port": 5432,
+      "database": "daz",
+      "user": "your_db_user",
+      "password": "your_db_password"
     }
-  ],
-  "database": {
-    "type": "postgres",
-    "host": "localhost",
-    "port": 5432,
-    "username": "your_db_user",
-    "password": "your_db_password",
-    "database": "daz"
+  },
+  "event_bus": {
+    "buffer_sizes": {
+      "cytube.event": 1000,
+      "sql.request": 100,
+      "plugin.request": 50
+    }
+  },
+  "plugins": {
+    "eventfilter": {
+      "command_prefix": "!"
+    },
+    "economy": {}
   }
 }

--- a/docs/economy.md
+++ b/docs/economy.md
@@ -1,0 +1,373 @@
+# Economy Plugin Contract (v1)
+
+This document defines the stable request/response contract for the `economy` plugin over the EventBus `plugin.request` pattern.
+
+It is intentionally narrow: operation names, payload shape, correlation, idempotency, and error codes.
+
+## Transport
+
+- Event type: `plugin.request`
+- Request envelope: `framework.EventData.PluginRequest` (serialized as `plugin_request`)
+- Response envelope: `framework.EventData.PluginResponse` (serialized as `plugin_response`)
+
+The economy plugin routes requests using the payload only. Handlers do not receive `EventMetadata`, so anything required for correlation, idempotency, or semantics must be present in the request payload.
+
+## Correlation rules (required)
+
+The correlation ID for a request is `PluginRequest.ID`.
+
+- `PluginRequest.ID` MUST be unique per logical request.
+- The economy plugin MUST call `eventBus.DeliverResponse(req.ID, resp, err)`.
+- If the caller uses `eventBus.Request(...)` (synchronous request/reply), it MUST also set `EventMetadata.CorrelationID` to the same value as `PluginRequest.ID`, otherwise the caller will wait on a correlation ID the handler cannot see.
+
+## Idempotency rules (credit, debit, transfer)
+
+Operations that change balances are idempotent.
+
+- Request payload MAY include `idempotency_key`.
+- If `idempotency_key` is omitted or empty, the server defaults it to `PluginRequest.ID`.
+- If the same idempotency key is seen again with an identical payload, the operation is not applied again and the response sets `already_applied=true`.
+- If the same idempotency key is seen again with a different payload, the request fails with `error_code=IDEMPOTENCY_CONFLICT`.
+
+Clients should retry by re-sending the same JSON fields and values.
+
+## Error codes
+
+On failure, the response uses `PluginResponse.Success=false` and includes a deterministic `error_code` in `PluginResponse.Data.RawJSON`.
+
+- `INVALID_ARGUMENT`: missing required fields, invalid types, invalid JSON for `data.raw_json`, unknown operation name.
+- `INVALID_AMOUNT`: `amount` is missing, not an integer, or is less than or equal to 0.
+- `INSUFFICIENT_FUNDS`: debit or transfer would make the sender balance negative.
+- `IDEMPOTENCY_CONFLICT`: duplicate idempotency key with a different payload.
+- `DB_UNAVAILABLE`: database layer is not ready (for example SQL plugin down) or requests cannot be executed.
+- `DB_ERROR`: database operation failed after the DB layer was available.
+- `INTERNAL`: any unexpected error.
+
+## Request envelope
+
+`PluginRequest` fields:
+
+- `id` (string, required): correlation ID. See correlation rules.
+- `from` (string, required): the sending plugin name.
+- `to` (string, required): MUST be `"economy"`.
+- `type` (string, required): operation name. See operations.
+- `data.raw_json` (object, required): operation-specific request payload.
+
+Example (shape only):
+
+```json
+{
+  "plugin_request": {
+    "id": "1719953890644416000",
+    "from": "myplugin",
+    "to": "economy",
+    "type": "economy.get_balance",
+    "data": {
+      "raw_json": {
+        "channel": "my-channel",
+        "username": "alice"
+      }
+    }
+  }
+}
+```
+
+## Response envelope
+
+`PluginResponse` fields:
+
+- `id` (string, required): MUST equal the request `PluginRequest.ID`.
+- `from` (string, required): MUST be `"economy"`.
+- `success` (bool, required)
+- `error` (string, optional): human-friendly message.
+- `data.raw_json` (object, optional): operation result, or an error object.
+
+Error payload shape:
+
+```json
+{
+  "error_code": "INVALID_ARGUMENT",
+  "message": "missing field channel",
+  "details": {
+    "field": "channel"
+  }
+}
+```
+
+## Operations
+
+Operation names are stable and MUST match exactly:
+
+- `economy.get_balance`
+- `economy.credit`
+- `economy.debit`
+- `economy.transfer`
+
+All operations are channel-scoped.
+
+### economy.get_balance
+
+Request `data.raw_json`:
+
+- `channel` (string, required)
+- `username` (string, required)
+
+Response `data.raw_json` (success):
+
+- `channel` (string)
+- `username` (string)
+- `balance` (integer)
+
+Request example:
+
+```json
+{
+  "plugin_request": {
+    "id": "bal-1719953890644416000",
+    "from": "myplugin",
+    "to": "economy",
+    "type": "economy.get_balance",
+    "data": {
+      "raw_json": {
+        "channel": "my-channel",
+        "username": "alice"
+      }
+    }
+  }
+}
+```
+
+Response example:
+
+```json
+{
+  "plugin_response": {
+    "id": "bal-1719953890644416000",
+    "from": "economy",
+    "success": true,
+    "data": {
+      "raw_json": {
+        "channel": "my-channel",
+        "username": "alice",
+        "balance": 1250
+      }
+    }
+  }
+}
+```
+
+### economy.credit
+
+Request `data.raw_json`:
+
+- `channel` (string, required)
+- `username` (string, required)
+- `amount` (integer, required, must be greater than 0)
+- `idempotency_key` (string, optional)
+- `reason` (string, optional)
+- `metadata` (object, optional)
+
+Response `data.raw_json` (success):
+
+- `channel` (string)
+- `username` (string)
+- `amount` (integer)
+- `balance_before` (integer)
+- `balance_after` (integer)
+- `idempotency_key` (string)
+- `already_applied` (bool)
+
+Request example:
+
+```json
+{
+  "plugin_request": {
+    "id": "cred-1719953890644416000",
+    "from": "myplugin",
+    "to": "economy",
+    "type": "economy.credit",
+    "data": {
+      "raw_json": {
+        "channel": "my-channel",
+        "username": "alice",
+        "amount": 250,
+        "idempotency_key": "txn-8f2d0d4a",
+        "reason": "daily_reward",
+        "metadata": {
+          "source": "rewards",
+          "campaign": "mar-2026"
+        }
+      }
+    }
+  }
+}
+```
+
+Response example:
+
+```json
+{
+  "plugin_response": {
+    "id": "cred-1719953890644416000",
+    "from": "economy",
+    "success": true,
+    "data": {
+      "raw_json": {
+        "channel": "my-channel",
+        "username": "alice",
+        "amount": 250,
+        "balance_before": 1250,
+        "balance_after": 1500,
+        "idempotency_key": "txn-8f2d0d4a",
+        "already_applied": false
+      }
+    }
+  }
+}
+```
+
+### economy.debit
+
+Request `data.raw_json`:
+
+- `channel` (string, required)
+- `username` (string, required)
+- `amount` (integer, required, must be greater than 0)
+- `idempotency_key` (string, optional)
+- `reason` (string, optional)
+- `metadata` (object, optional)
+
+Response `data.raw_json` (success):
+
+- `channel` (string)
+- `username` (string)
+- `amount` (integer)
+- `balance_before` (integer)
+- `balance_after` (integer)
+- `idempotency_key` (string)
+- `already_applied` (bool)
+
+Request example:
+
+```json
+{
+  "plugin_request": {
+    "id": "debit-1719953890644416000",
+    "from": "myplugin",
+    "to": "economy",
+    "type": "economy.debit",
+    "data": {
+      "raw_json": {
+        "channel": "my-channel",
+        "username": "alice",
+        "amount": 300,
+        "reason": "shop_purchase",
+        "metadata": {
+          "item_id": "sword_01"
+        }
+      }
+    }
+  }
+}
+```
+
+Response example (insufficient funds):
+
+```json
+{
+  "plugin_response": {
+    "id": "debit-1719953890644416000",
+    "from": "economy",
+    "success": false,
+    "error": "insufficient funds",
+    "data": {
+      "raw_json": {
+        "error_code": "INSUFFICIENT_FUNDS",
+        "message": "debit would make balance negative",
+        "details": {
+          "channel": "my-channel",
+          "username": "alice",
+          "amount": 300
+        }
+      }
+    }
+  }
+}
+```
+
+### economy.transfer
+
+Request `data.raw_json`:
+
+- `channel` (string, required)
+- `from_username` (string, required)
+- `to_username` (string, required)
+- `amount` (integer, required, must be greater than 0)
+- `idempotency_key` (string, optional)
+- `reason` (string, optional)
+- `metadata` (object, optional)
+
+Response `data.raw_json` (success):
+
+- `channel` (string)
+- `from_username` (string)
+- `to_username` (string)
+- `amount` (integer)
+- `from_balance_before` (integer)
+- `from_balance_after` (integer)
+- `to_balance_before` (integer)
+- `to_balance_after` (integer)
+- `idempotency_key` (string)
+- `already_applied` (bool)
+
+Request example:
+
+```json
+{
+  "plugin_request": {
+    "id": "xfer-1719953890644416000",
+    "from": "myplugin",
+    "to": "economy",
+    "type": "economy.transfer",
+    "data": {
+      "raw_json": {
+        "channel": "my-channel",
+        "from_username": "alice",
+        "to_username": "bob",
+        "amount": 50,
+        "idempotency_key": "pay-20260301-0001",
+        "reason": "tip",
+        "metadata": {
+          "message_id": "chatmsg-001"
+        }
+      }
+    }
+  }
+}
+```
+
+Response example:
+
+```json
+{
+  "plugin_response": {
+    "id": "xfer-1719953890644416000",
+    "from": "economy",
+    "success": true,
+    "data": {
+      "raw_json": {
+        "channel": "my-channel",
+        "from_username": "alice",
+        "to_username": "bob",
+        "amount": 50,
+        "from_balance_before": 1500,
+        "from_balance_after": 1450,
+        "to_balance_before": 20,
+        "to_balance_after": 70,
+        "idempotency_key": "pay-20260301-0001",
+        "already_applied": false
+      }
+    }
+  }
+}
+```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,7 @@ import (
 type Config struct {
 	Core     CoreConfig              `json:"core"`
 	EventBus EventBusConfig          `json:"event_bus"`
-	Plugins  map[string]PluginConfig `json:"plugins"`
+	Plugins  map[string]PluginConfig `json:"plugins"` // e.g., "economy", "sql", "eventfilter"
 }
 
 // CoreConfig contains configuration for the core plugin

--- a/internal/framework/economy_client.go
+++ b/internal/framework/economy_client.go
@@ -1,0 +1,268 @@
+package framework
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// EconomyError represents a structured error from the economy plugin
+type EconomyError struct {
+	ErrorCode string          `json:"error_code"`
+	Message   string          `json:"message"`
+	Details   json.RawMessage `json:"details,omitempty"`
+}
+
+func (e *EconomyError) Error() string {
+	return fmt.Sprintf("economy error (%s): %s", e.ErrorCode, e.Message)
+}
+
+// EconomyClient provides a high-level API for interacting with the economy plugin
+type EconomyClient struct {
+	eventBus EventBus
+	source   string
+	helper   *RequestHelper
+}
+
+// NewEconomyClient creates a new economy client
+func NewEconomyClient(eventBus EventBus, source string) *EconomyClient {
+	return &EconomyClient{
+		eventBus: eventBus,
+		source:   source,
+		helper:   NewRequestHelper(eventBus, source),
+	}
+}
+
+// GetBalanceRequest represents the request payload for economy.get_balance
+type GetBalanceRequest struct {
+	Channel  string `json:"channel"`
+	Username string `json:"username"`
+}
+
+// GetBalanceResponse represents the response payload for economy.get_balance
+type GetBalanceResponse struct {
+	Channel  string `json:"channel"`
+	Username string `json:"username"`
+	Balance  int64  `json:"balance"`
+}
+
+// CreditRequest represents the request payload for economy.credit
+type CreditRequest struct {
+	Channel        string          `json:"channel"`
+	Username       string          `json:"username"`
+	Amount         int64           `json:"amount"`
+	IdempotencyKey string          `json:"idempotency_key,omitempty"`
+	Reason         string          `json:"reason,omitempty"`
+	Metadata       json.RawMessage `json:"metadata,omitempty"`
+}
+
+// CreditResponse represents the response payload for economy.credit
+type CreditResponse struct {
+	Channel        string `json:"channel"`
+	Username       string `json:"username"`
+	Amount         int64  `json:"amount"`
+	BalanceBefore  int64  `json:"balance_before"`
+	BalanceAfter   int64  `json:"balance_after"`
+	IdempotencyKey string `json:"idempotency_key"`
+	AlreadyApplied bool   `json:"already_applied"`
+}
+
+// DebitRequest represents the request payload for economy.debit
+type DebitRequest struct {
+	Channel        string          `json:"channel"`
+	Username       string          `json:"username"`
+	Amount         int64           `json:"amount"`
+	IdempotencyKey string          `json:"idempotency_key,omitempty"`
+	Reason         string          `json:"reason,omitempty"`
+	Metadata       json.RawMessage `json:"metadata,omitempty"`
+}
+
+// DebitResponse represents the response payload for economy.debit
+type DebitResponse struct {
+	Channel        string `json:"channel"`
+	Username       string `json:"username"`
+	Amount         int64  `json:"amount"`
+	BalanceBefore  int64  `json:"balance_before"`
+	BalanceAfter   int64  `json:"balance_after"`
+	IdempotencyKey string `json:"idempotency_key"`
+	AlreadyApplied bool   `json:"already_applied"`
+}
+
+// TransferRequest represents the request payload for economy.transfer
+type TransferRequest struct {
+	Channel        string          `json:"channel"`
+	FromUsername   string          `json:"from_username"`
+	ToUsername     string          `json:"to_username"`
+	Amount         int64           `json:"amount"`
+	IdempotencyKey string          `json:"idempotency_key,omitempty"`
+	Reason         string          `json:"reason,omitempty"`
+	Metadata       json.RawMessage `json:"metadata,omitempty"`
+}
+
+// TransferResponse represents the response payload for economy.transfer
+type TransferResponse struct {
+	Channel           string `json:"channel"`
+	FromUsername      string `json:"from_username"`
+	ToUsername        string `json:"to_username"`
+	Amount            int64  `json:"amount"`
+	FromBalanceBefore int64  `json:"from_balance_before"`
+	FromBalanceAfter  int64  `json:"from_balance_after"`
+	ToBalanceBefore   int64  `json:"to_balance_before"`
+	ToBalanceAfter    int64  `json:"to_balance_after"`
+	IdempotencyKey    string `json:"idempotency_key"`
+	AlreadyApplied    bool   `json:"already_applied"`
+}
+
+// GetBalance retrieves the balance for a user in a channel
+func (c *EconomyClient) GetBalance(ctx context.Context, channel, username string) (int64, error) {
+	reqPayload := GetBalanceRequest{
+		Channel:  channel,
+		Username: username,
+	}
+
+	var respPayload GetBalanceResponse
+	err := c.doRequest(ctx, "economy.get_balance", reqPayload, &respPayload)
+	if err != nil {
+		return 0, err
+	}
+
+	return respPayload.Balance, nil
+}
+
+// Credit adds funds to a user's balance
+func (c *EconomyClient) Credit(ctx context.Context, req CreditRequest) (*CreditResponse, error) {
+	var resp CreditResponse
+	err := c.doRequest(ctx, "economy.credit", &req, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// Debit removes funds from a user's balance
+func (c *EconomyClient) Debit(ctx context.Context, req DebitRequest) (*DebitResponse, error) {
+	var resp DebitResponse
+	err := c.doRequest(ctx, "economy.debit", &req, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// Transfer moves funds from one user to another
+func (c *EconomyClient) Transfer(ctx context.Context, req TransferRequest) (*TransferResponse, error) {
+	var resp TransferResponse
+	err := c.doRequest(ctx, "economy.transfer", &req, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *EconomyClient) doRequest(ctx context.Context, opType string, payload any, result any) error {
+	correlationID := fmt.Sprintf("%s-%d", c.source, time.Now().UnixNano())
+
+	// Handle idempotency defaults for mutation operations
+	if opType != "economy.get_balance" {
+		switch p := payload.(type) {
+		case *CreditRequest:
+			if p.IdempotencyKey == "" {
+				p.IdempotencyKey = correlationID
+			}
+		case *DebitRequest:
+			if p.IdempotencyKey == "" {
+				p.IdempotencyKey = correlationID
+			}
+		case *TransferRequest:
+			if p.IdempotencyKey == "" {
+				p.IdempotencyKey = correlationID
+			}
+		case CreditRequest:
+			if p.IdempotencyKey == "" {
+				p.IdempotencyKey = correlationID
+				payload = p
+			}
+		case DebitRequest:
+			if p.IdempotencyKey == "" {
+				p.IdempotencyKey = correlationID
+				payload = p
+			}
+		case TransferRequest:
+			if p.IdempotencyKey == "" {
+				p.IdempotencyKey = correlationID
+				payload = p
+			}
+		}
+	}
+
+	rawPayload, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal payload: %w", err)
+	}
+
+	data := &EventData{
+		PluginRequest: &PluginRequest{
+			ID:   correlationID,
+			From: c.source,
+			To:   "economy",
+			Type: opType,
+			Data: &RequestData{
+				RawJSON: rawPayload,
+			},
+		},
+	}
+
+	metadata := &EventMetadata{
+		CorrelationID: correlationID,
+		Timestamp:     time.Now(),
+		Source:        c.source,
+		Target:        "economy",
+	}
+
+	// Determine timeout from context
+	configName := "normal"
+	if deadline, ok := ctx.Deadline(); ok {
+		timeout := time.Until(deadline)
+		switch {
+		case timeout <= 5*time.Second:
+			configName = "fast"
+		case timeout <= 15*time.Second:
+			configName = "normal"
+		case timeout <= 30*time.Second:
+			configName = "slow"
+		default:
+			configName = "critical"
+		}
+		metadata.Timeout = timeout
+	}
+
+	respEvent, err := c.helper.RequestWithConfig(ctx, "economy", "plugin.request", data, configName)
+	if err != nil {
+		return err
+	}
+
+	if respEvent == nil || respEvent.PluginResponse == nil {
+		return fmt.Errorf("no plugin response received")
+	}
+
+	pluginResp := respEvent.PluginResponse
+	if !pluginResp.Success {
+		// Try to parse structured error from RawJSON
+		if pluginResp.Data != nil && len(pluginResp.Data.RawJSON) > 0 {
+			var econErr EconomyError
+			if json.Unmarshal(pluginResp.Data.RawJSON, &econErr) == nil && econErr.ErrorCode != "" {
+				return &econErr
+			}
+		}
+		return fmt.Errorf("plugin request failed: %s", pluginResp.Error)
+	}
+
+	if result != nil && pluginResp.Data != nil && len(pluginResp.Data.RawJSON) > 0 {
+		if err := json.Unmarshal(pluginResp.Data.RawJSON, result); err != nil {
+			return fmt.Errorf("failed to unmarshal response data: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/framework/economy_client_test.go
+++ b/internal/framework/economy_client_test.go
@@ -1,0 +1,216 @@
+package framework
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type mockEconomyEventBus struct {
+	lastRequest  *EventData
+	lastMetadata *EventMetadata
+	mockResponse *EventData
+	mockErr      error
+}
+
+func (m *mockEconomyEventBus) Broadcast(eventType string, data *EventData) error { return nil }
+func (m *mockEconomyEventBus) BroadcastWithMetadata(eventType string, data *EventData, metadata *EventMetadata) error {
+	return nil
+}
+func (m *mockEconomyEventBus) Send(target string, eventType string, data *EventData) error {
+	return nil
+}
+func (m *mockEconomyEventBus) SendWithMetadata(target string, eventType string, data *EventData, metadata *EventMetadata) error {
+	return nil
+}
+func (m *mockEconomyEventBus) Request(ctx context.Context, target string, eventType string, data *EventData, metadata *EventMetadata) (*EventData, error) {
+	m.lastRequest = data
+	m.lastMetadata = metadata
+	if m.mockResponse != nil && m.mockResponse.PluginResponse != nil && data.PluginRequest != nil {
+		m.mockResponse.PluginResponse.ID = data.PluginRequest.ID
+	}
+	return m.mockResponse, m.mockErr
+}
+func (m *mockEconomyEventBus) DeliverResponse(correlationID string, response *EventData, err error) {}
+func (m *mockEconomyEventBus) Subscribe(eventType string, handler EventHandler) error               { return nil }
+func (m *mockEconomyEventBus) SubscribeWithTags(pattern string, handler EventHandler, tags []string) error {
+	return nil
+}
+func (m *mockEconomyEventBus) RegisterPlugin(name string, plugin Plugin) error { return nil }
+func (m *mockEconomyEventBus) UnregisterPlugin(name string) error              { return nil }
+func (m *mockEconomyEventBus) GetDroppedEventCounts() map[string]int64         { return nil }
+func (m *mockEconomyEventBus) GetDroppedEventCount(eventType string) int64     { return 0 }
+
+func TestEconomyClient_CorrelationMirrored(t *testing.T) {
+	mockBus := &mockEconomyEventBus{}
+	client := NewEconomyClient(mockBus, "test-plugin")
+
+	// Set up mock response
+	respData, _ := json.Marshal(GetBalanceResponse{
+		Channel:  "test-channel",
+		Username: "alice",
+		Balance:  1000,
+	})
+	mockBus.mockResponse = &EventData{
+		PluginResponse: &PluginResponse{
+			Success: true,
+			Data: &ResponseData{
+				RawJSON: respData,
+			},
+		},
+	}
+
+	ctx := context.Background()
+	_, err := client.GetBalance(ctx, "test-channel", "alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify correlation ID mirroring
+	if mockBus.lastMetadata.CorrelationID == "" {
+		t.Error("expected non-empty correlation ID in metadata")
+	}
+	if mockBus.lastRequest.PluginRequest.ID == "" {
+		t.Error("expected non-empty correlation ID in plugin request")
+	}
+	if mockBus.lastMetadata.CorrelationID != mockBus.lastRequest.PluginRequest.ID {
+		t.Errorf("correlation ID mismatch: metadata=%s, request=%s",
+			mockBus.lastMetadata.CorrelationID, mockBus.lastRequest.PluginRequest.ID)
+	}
+}
+
+func TestEconomyClient_IdempotencyDefault(t *testing.T) {
+	mockBus := &mockEconomyEventBus{}
+	client := NewEconomyClient(mockBus, "test-plugin")
+
+	// Set up mock response for Credit
+	respData, _ := json.Marshal(CreditResponse{
+		Channel:        "test-channel",
+		Username:       "alice",
+		Amount:         100,
+		BalanceBefore:  1000,
+		BalanceAfter:   1100,
+		IdempotencyKey: "auto-gen-key",
+		AlreadyApplied: false,
+	})
+	mockBus.mockResponse = &EventData{
+		PluginResponse: &PluginResponse{
+			Success: true,
+			Data: &ResponseData{
+				RawJSON: respData,
+			},
+		},
+	}
+
+	ctx := context.Background()
+	_, err := client.Credit(ctx, CreditRequest{
+		Channel:  "test-channel",
+		Username: "alice",
+		Amount:   100,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify idempotency key was defaulted to correlation ID
+	var req CreditRequest
+	if err := json.Unmarshal(mockBus.lastRequest.PluginRequest.Data.RawJSON, &req); err != nil {
+		t.Fatalf("failed to unmarshal request: %v", err)
+	}
+
+	correlationID := mockBus.lastRequest.PluginRequest.ID
+	if req.IdempotencyKey == "" {
+		t.Error("expected idempotency key to be populated")
+	}
+	if req.IdempotencyKey != correlationID {
+		t.Errorf("expected idempotency key to match correlation ID, got %s, want %s",
+			req.IdempotencyKey, correlationID)
+	}
+}
+
+func TestEconomyClient_ErrorHandling(t *testing.T) {
+	mockBus := &mockEconomyEventBus{}
+	client := NewEconomyClient(mockBus, "test-plugin")
+
+	// Set up structured error response
+	errData, _ := json.Marshal(EconomyError{
+		ErrorCode: "INSUFFICIENT_FUNDS",
+		Message:   "not enough money",
+	})
+	mockBus.mockResponse = &EventData{
+		PluginResponse: &PluginResponse{
+			Success: false,
+			Error:   "insufficient funds",
+			Data: &ResponseData{
+				RawJSON: errData,
+			},
+		},
+	}
+
+	ctx := context.Background()
+	_, err := client.Debit(ctx, DebitRequest{
+		Channel:  "test-channel",
+		Username: "alice",
+		Amount:   5000,
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	econErr, ok := err.(*EconomyError)
+	if !ok {
+		t.Fatalf("expected *EconomyError, got %T", err)
+	}
+
+	if econErr.ErrorCode != "INSUFFICIENT_FUNDS" {
+		t.Errorf("expected error code INSUFFICIENT_FUNDS, got %s", econErr.ErrorCode)
+	}
+}
+
+func TestEconomyClient_TransferHappyPath(t *testing.T) {
+	mockBus := &mockEconomyEventBus{}
+	client := NewEconomyClient(mockBus, "test-plugin")
+
+	// Set up mock response for Transfer
+	respData, _ := json.Marshal(TransferResponse{
+		Channel:           "test-channel",
+		FromUsername:      "alice",
+		ToUsername:        "bob",
+		Amount:            50,
+		FromBalanceBefore: 1000,
+		FromBalanceAfter:  950,
+		ToBalanceBefore:   100,
+		ToBalanceAfter:    150,
+		IdempotencyKey:    "xfer-key",
+		AlreadyApplied:    false,
+	})
+	mockBus.mockResponse = &EventData{
+		PluginResponse: &PluginResponse{
+			Success: true,
+			Data: &ResponseData{
+				RawJSON: respData,
+			},
+		},
+	}
+
+	ctx := context.Background()
+	resp, err := client.Transfer(ctx, TransferRequest{
+		Channel:      "test-channel",
+		FromUsername: "alice",
+		ToUsername:   "bob",
+		Amount:       50,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.FromBalanceAfter != 950 || resp.ToBalanceAfter != 150 {
+		t.Errorf("unexpected balances in response: from=%d, to=%d", resp.FromBalanceAfter, resp.ToBalanceAfter)
+	}
+
+	// Verify request type
+	if mockBus.lastRequest.PluginRequest.Type != "economy.transfer" {
+		t.Errorf("expected type economy.transfer, got %s", mockBus.lastRequest.PluginRequest.Type)
+	}
+}

--- a/internal/framework/request_helper.go
+++ b/internal/framework/request_helper.go
@@ -207,6 +207,9 @@ func (h *RequestHelper) requestWithRetry(
 
 	// Generate correlation ID
 	correlationID := fmt.Sprintf("%s-%d", h.source, time.Now().UnixNano())
+	if data != nil && data.PluginRequest != nil && data.PluginRequest.ID != "" {
+		correlationID = data.PluginRequest.ID
+	}
 
 	// Create metadata
 	metadata := &EventMetadata{
@@ -228,6 +231,9 @@ func (h *RequestHelper) requestWithRetry(
 		}
 		if data.SQLBatchRequest != nil {
 			data.SQLBatchRequest.CorrelationID = correlationID
+		}
+		if data.PluginRequest != nil {
+			data.PluginRequest.ID = correlationID
 		}
 	}
 

--- a/internal/plugins/economy/integration_test.go
+++ b/internal/plugins/economy/integration_test.go
@@ -1,0 +1,424 @@
+//go:build integration
+// +build integration
+
+package economy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hildolfr/daz/internal/framework"
+	sqlplugin "github.com/hildolfr/daz/internal/plugins/sql"
+	"github.com/hildolfr/daz/pkg/eventbus"
+)
+
+type integrationHarness struct {
+	eventBus *eventbus.EventBus
+	plugins  *framework.PluginManager
+	client   *framework.EconomyClient
+}
+
+func TestTransfer_IdempotentSameKey(t *testing.T) {
+	h := newIntegrationHarness(t)
+	t.Cleanup(h.close)
+
+	channel := testChannel("idempotent")
+	alice := fmt.Sprintf("alice-%d", time.Now().UnixNano())
+	bob := fmt.Sprintf("bob-%d", time.Now().UnixNano())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	_, err := h.client.Credit(ctx, framework.CreditRequest{
+		Channel:        channel,
+		Username:       alice,
+		Amount:         1000,
+		IdempotencyKey: fmt.Sprintf("credit-%d", time.Now().UnixNano()),
+		Reason:         "integration setup",
+	})
+	if err != nil {
+		t.Fatalf("credit alice: %v", err)
+	}
+
+	key := fmt.Sprintf("transfer-same-key-%d", time.Now().UnixNano())
+	transferReq := framework.TransferRequest{
+		Channel:        channel,
+		FromUsername:   alice,
+		ToUsername:     bob,
+		Amount:         250,
+		IdempotencyKey: key,
+		Reason:         "idempotency verification",
+	}
+
+	firstResp, err := h.client.Transfer(ctx, transferReq)
+	if err != nil {
+		t.Fatalf("first transfer: %v", err)
+	}
+	if firstResp.AlreadyApplied {
+		t.Fatal("expected first transfer to be newly applied")
+	}
+
+	secondResp, err := h.client.Transfer(ctx, transferReq)
+	if err != nil {
+		t.Fatalf("second transfer with same key: %v", err)
+	}
+	if !secondResp.AlreadyApplied {
+		t.Fatal("expected second transfer to report already_applied=true")
+	}
+
+	aliceBalance, err := h.client.GetBalance(ctx, channel, alice)
+	if err != nil {
+		t.Fatalf("get alice balance: %v", err)
+	}
+	bobBalance, err := h.client.GetBalance(ctx, channel, bob)
+	if err != nil {
+		t.Fatalf("get bob balance: %v", err)
+	}
+
+	if aliceBalance != 750 {
+		t.Fatalf("expected alice balance 750, got %d", aliceBalance)
+	}
+	if bobBalance != 250 {
+		t.Fatalf("expected bob balance 250, got %d", bobBalance)
+	}
+}
+
+func TestTransfer_IdempotencyConflict(t *testing.T) {
+	h := newIntegrationHarness(t)
+	t.Cleanup(h.close)
+
+	channel := testChannel("conflict")
+	alice := fmt.Sprintf("alice-%d", time.Now().UnixNano())
+	bob := fmt.Sprintf("bob-%d", time.Now().UnixNano())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	_, err := h.client.Credit(ctx, framework.CreditRequest{
+		Channel:        channel,
+		Username:       alice,
+		Amount:         1000,
+		IdempotencyKey: fmt.Sprintf("credit-%d", time.Now().UnixNano()),
+		Reason:         "integration setup",
+	})
+	if err != nil {
+		t.Fatalf("credit alice: %v", err)
+	}
+
+	key := fmt.Sprintf("transfer-conflict-key-%d", time.Now().UnixNano())
+	_, err = h.client.Transfer(ctx, framework.TransferRequest{
+		Channel:        channel,
+		FromUsername:   alice,
+		ToUsername:     bob,
+		Amount:         100,
+		IdempotencyKey: key,
+		Reason:         "first apply",
+	})
+	if err != nil {
+		t.Fatalf("first transfer: %v", err)
+	}
+
+	_, err = h.client.Transfer(ctx, framework.TransferRequest{
+		Channel:        channel,
+		FromUsername:   alice,
+		ToUsername:     bob,
+		Amount:         125,
+		IdempotencyKey: key,
+		Reason:         "conflicting payload",
+	})
+	if err == nil {
+		t.Fatal("expected idempotency conflict on second transfer")
+	}
+
+	var economyErr *framework.EconomyError
+	if !errors.As(err, &economyErr) {
+		t.Fatalf("expected EconomyError, got %T (%v)", err, err)
+	}
+	if economyErr.ErrorCode != "IDEMPOTENCY_CONFLICT" {
+		t.Fatalf("expected error_code IDEMPOTENCY_CONFLICT, got %q", economyErr.ErrorCode)
+	}
+
+	aliceBalance, err := h.client.GetBalance(ctx, channel, alice)
+	if err != nil {
+		t.Fatalf("get alice balance: %v", err)
+	}
+	bobBalance, err := h.client.GetBalance(ctx, channel, bob)
+	if err != nil {
+		t.Fatalf("get bob balance: %v", err)
+	}
+
+	if aliceBalance != 900 {
+		t.Fatalf("expected alice balance 900 after conflict, got %d", aliceBalance)
+	}
+	if bobBalance != 100 {
+		t.Fatalf("expected bob balance 100 after conflict, got %d", bobBalance)
+	}
+}
+
+func TestTransfer_ConcurrentOpposing(t *testing.T) {
+	h := newIntegrationHarness(t)
+	t.Cleanup(h.close)
+
+	channel := testChannel("concurrent")
+	userA := fmt.Sprintf("usera-%d", time.Now().UnixNano())
+	userB := fmt.Sprintf("userb-%d", time.Now().UnixNano())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	_, err := h.client.Credit(ctx, framework.CreditRequest{
+		Channel:        channel,
+		Username:       userA,
+		Amount:         1000,
+		IdempotencyKey: fmt.Sprintf("credit-a-%d", time.Now().UnixNano()),
+		Reason:         "integration setup",
+	})
+	if err != nil {
+		t.Fatalf("credit userA: %v", err)
+	}
+	_, err = h.client.Credit(ctx, framework.CreditRequest{
+		Channel:        channel,
+		Username:       userB,
+		Amount:         1000,
+		IdempotencyKey: fmt.Sprintf("credit-b-%d", time.Now().UnixNano()),
+		Reason:         "integration setup",
+	})
+	if err != nil {
+		t.Fatalf("credit userB: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, transferErr := h.client.Transfer(ctx, framework.TransferRequest{
+			Channel:        channel,
+			FromUsername:   userA,
+			ToUsername:     userB,
+			Amount:         175,
+			IdempotencyKey: fmt.Sprintf("concurrent-a-to-b-%d", time.Now().UnixNano()),
+			Reason:         "concurrency test",
+		})
+		errs <- transferErr
+	}()
+
+	go func() {
+		defer wg.Done()
+		_, transferErr := h.client.Transfer(ctx, framework.TransferRequest{
+			Channel:        channel,
+			FromUsername:   userB,
+			ToUsername:     userA,
+			Amount:         40,
+			IdempotencyKey: fmt.Sprintf("concurrent-b-to-a-%d", time.Now().UnixNano()),
+			Reason:         "concurrency test",
+		})
+		errs <- transferErr
+	}()
+
+	wg.Wait()
+	close(errs)
+
+	for transferErr := range errs {
+		if transferErr != nil {
+			t.Fatalf("concurrent transfer returned error: %v", transferErr)
+		}
+	}
+
+	balanceA, err := h.client.GetBalance(ctx, channel, userA)
+	if err != nil {
+		t.Fatalf("get userA balance: %v", err)
+	}
+	balanceB, err := h.client.GetBalance(ctx, channel, userB)
+	if err != nil {
+		t.Fatalf("get userB balance: %v", err)
+	}
+
+	if balanceA != 865 {
+		t.Fatalf("expected userA balance 865, got %d", balanceA)
+	}
+	if balanceB != 1135 {
+		t.Fatalf("expected userB balance 1135, got %d", balanceB)
+	}
+	if balanceA < 0 || balanceB < 0 {
+		t.Fatalf("expected non-negative balances, got userA=%d userB=%d", balanceA, balanceB)
+	}
+}
+
+func newIntegrationHarness(t *testing.T) *integrationHarness {
+	t.Helper()
+
+	// Change working directory to repo root so SQL migrations can be found.
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to get caller info")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(filename), "../../.."))
+
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatalf("failed to change dir to %s: %v", repoRoot, err)
+	}
+
+	t.Cleanup(func() {
+		if err := os.Chdir(oldCwd); err != nil {
+			t.Errorf("failed to restore cwd: %v", err)
+		}
+	})
+
+	sqlConfig := mustBuildSQLConfigFromEnv(t)
+
+	bus := eventbus.NewEventBus(nil)
+	if err := bus.Start(); err != nil {
+		t.Fatalf("start event bus: %v", err)
+	}
+
+	pm := framework.NewPluginManager()
+	sqlPlugin := sqlplugin.NewPlugin()
+	economyPlugin := New()
+	if err := pm.RegisterPlugin("sql", sqlPlugin); err != nil {
+		_ = bus.Stop()
+		t.Fatalf("register sql plugin: %v", err)
+	}
+	if err := pm.RegisterPlugin(pluginName, economyPlugin); err != nil {
+		_ = bus.Stop()
+		t.Fatalf("register economy plugin: %v", err)
+	}
+
+	pluginConfigs := map[string]json.RawMessage{
+		"sql":     sqlConfig,
+		"economy": json.RawMessage(`{}`),
+	}
+	if err := pm.InitializeAll(pluginConfigs, bus); err != nil {
+		_ = bus.Stop()
+		t.Fatalf("initialize plugins: %v", err)
+	}
+	if err := pm.StartAll(); err != nil {
+		pm.StopAll()
+		_ = bus.Stop()
+		t.Fatalf("start plugins: %v", err)
+	}
+
+	if err := waitForPluginReadiness([]framework.Plugin{sqlPlugin, economyPlugin}, 20*time.Second); err != nil {
+		pm.StopAll()
+		_ = bus.Stop()
+		t.Fatalf("wait for readiness: %v", err)
+	}
+
+	return &integrationHarness{
+		eventBus: bus,
+		plugins:  pm,
+		client:   framework.NewEconomyClient(bus, "economy-integration-test"),
+	}
+}
+
+func (h *integrationHarness) close() {
+	if h == nil {
+		return
+	}
+	h.plugins.StopAll()
+	_ = h.eventBus.Stop()
+}
+
+func mustBuildSQLConfigFromEnv(t *testing.T) json.RawMessage {
+	t.Helper()
+
+	host := os.Getenv("DAZ_DB_HOST")
+	portRaw := os.Getenv("DAZ_DB_PORT")
+	database := os.Getenv("DAZ_DB_NAME")
+	user := os.Getenv("DAZ_DB_USER")
+	password := os.Getenv("DAZ_DB_PASSWORD")
+
+	missing := make([]string, 0, 5)
+	if host == "" {
+		missing = append(missing, "DAZ_DB_HOST")
+	}
+	if portRaw == "" {
+		missing = append(missing, "DAZ_DB_PORT")
+	}
+	if database == "" {
+		missing = append(missing, "DAZ_DB_NAME")
+	}
+	if user == "" {
+		missing = append(missing, "DAZ_DB_USER")
+	}
+	if password == "" {
+		missing = append(missing, "DAZ_DB_PASSWORD")
+	}
+	if len(missing) > 0 {
+		t.Skipf("skipping integration test, missing DB env vars: %v", missing)
+	}
+
+	port, err := strconv.Atoi(portRaw)
+	if err != nil {
+		t.Fatalf("invalid DAZ_DB_PORT %q: %v", portRaw, err)
+	}
+
+	config := map[string]interface{}{
+		"database": map[string]interface{}{
+			"host":              host,
+			"port":              port,
+			"database":          database,
+			"user":              user,
+			"password":          password,
+			"max_connections":   8,
+			"max_conn_lifetime": 300,
+			"connect_timeout":   10,
+		},
+		"logger_rules": []interface{}{},
+	}
+
+	raw, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshal sql plugin config: %v", err)
+	}
+
+	return raw
+}
+
+func waitForPluginReadiness(plugins []framework.Plugin, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		allReady := true
+		for _, plugin := range plugins {
+			readyPlugin, ok := plugin.(interface{ Ready() bool })
+			if !ok {
+				continue
+			}
+			if !readyPlugin.Ready() {
+				allReady = false
+				break
+			}
+		}
+
+		if allReady {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for plugin readiness")
+		}
+
+		<-ticker.C
+	}
+}
+
+func testChannel(suffix string) string {
+	return fmt.Sprintf("test-economy-%s-%d", suffix, time.Now().UnixNano())
+}

--- a/internal/plugins/economy/plugin.go
+++ b/internal/plugins/economy/plugin.go
@@ -1,0 +1,558 @@
+package economy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/hildolfr/daz/internal/framework"
+	"github.com/hildolfr/daz/pkg/eventbus"
+)
+
+const (
+	pluginName               = "economy"
+	errorCodeInvalidArg      = "INVALID_ARGUMENT"
+	errorCodeInvalidAmount   = "INVALID_AMOUNT"
+	errorCodeInsufficient    = "INSUFFICIENT_FUNDS"
+	errorCodeIdempotency     = "IDEMPOTENCY_CONFLICT"
+	errorCodeDBUnavailable   = "DB_UNAVAILABLE"
+	errorCodeDBError         = "DB_ERROR"
+	errorCodeInternal        = "INTERNAL"
+	operationGetBalance      = "economy.get_balance"
+	operationCredit          = "economy.credit"
+	operationDebit           = "economy.debit"
+	operationTransfer        = "economy.transfer"
+	stateInitialized         = "initialized"
+	stateRunning             = "running"
+	stateStopped             = "stopped"
+	nilResponseErrorTemplate = "operation %s failed"
+)
+
+type Plugin struct {
+	mu        sync.RWMutex
+	eventBus  framework.EventBus
+	store     Store
+	ctx       context.Context
+	cancel    context.CancelFunc
+	running   bool
+	readyChan chan struct{}
+	status    framework.PluginStatus
+}
+
+type getBalanceRequest struct {
+	Channel  string `json:"channel"`
+	Username string `json:"username"`
+}
+
+type creditRequest struct {
+	Channel        string                 `json:"channel"`
+	Username       string                 `json:"username"`
+	Amount         int64                  `json:"amount"`
+	IdempotencyKey string                 `json:"idempotency_key"`
+	Reason         string                 `json:"reason"`
+	Metadata       map[string]interface{} `json:"metadata"`
+}
+
+type debitRequest struct {
+	Channel        string                 `json:"channel"`
+	Username       string                 `json:"username"`
+	Amount         int64                  `json:"amount"`
+	IdempotencyKey string                 `json:"idempotency_key"`
+	Reason         string                 `json:"reason"`
+	Metadata       map[string]interface{} `json:"metadata"`
+}
+
+type transferRequest struct {
+	Channel        string                 `json:"channel"`
+	FromUsername   string                 `json:"from_username"`
+	ToUsername     string                 `json:"to_username"`
+	Amount         int64                  `json:"amount"`
+	IdempotencyKey string                 `json:"idempotency_key"`
+	Reason         string                 `json:"reason"`
+	Metadata       map[string]interface{} `json:"metadata"`
+}
+
+func New() framework.Plugin {
+	return &Plugin{
+		readyChan: make(chan struct{}),
+		status: framework.PluginStatus{
+			Name:  pluginName,
+			State: stateInitialized,
+		},
+	}
+}
+
+func (p *Plugin) Name() string {
+	return pluginName
+}
+
+func (p *Plugin) Dependencies() []string {
+	return []string{"sql"}
+}
+
+func (p *Plugin) Ready() bool {
+	select {
+	case <-p.readyChan:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *Plugin) Init(config json.RawMessage, bus framework.EventBus) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	_ = config
+	p.eventBus = bus
+	if p.store == nil {
+		sqlHelper := framework.NewSQLRequestHelper(bus, pluginName)
+		p.store = NewSQLStore(sqlHelper)
+	}
+	p.ctx, p.cancel = context.WithCancel(context.Background())
+	p.status = framework.PluginStatus{
+		Name:  pluginName,
+		State: stateInitialized,
+	}
+
+	return nil
+}
+
+func (p *Plugin) Start() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.running {
+		return fmt.Errorf("plugin already running")
+	}
+
+	if err := p.eventBus.Subscribe(eventbus.EventPluginRequest, p.handlePluginRequest); err != nil {
+		p.status.LastError = fmt.Errorf("failed to subscribe to plugin.request: %w", err)
+		return p.status.LastError
+	}
+
+	p.running = true
+	p.status.State = stateRunning
+	close(p.readyChan)
+
+	return nil
+}
+
+func (p *Plugin) Stop() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.running {
+		p.status.State = stateStopped
+		return nil
+	}
+
+	p.running = false
+	p.status.State = stateStopped
+	if p.cancel != nil {
+		p.cancel()
+	}
+
+	return nil
+}
+
+func (p *Plugin) HandleEvent(event framework.Event) error {
+	_ = event
+	return nil
+}
+
+func (p *Plugin) Status() framework.PluginStatus {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.status
+}
+
+func (p *Plugin) handlePluginRequest(event framework.Event) error {
+	dataEvent, ok := event.(*framework.DataEvent)
+	if !ok || dataEvent.Data == nil {
+		return nil
+	}
+
+	req := dataEvent.Data.PluginRequest
+	if req == nil {
+		return nil
+	}
+
+	if req.To != pluginName {
+		return nil
+	}
+
+	if req.ID == "" {
+		return nil
+	}
+
+	switch req.Type {
+	case operationGetBalance:
+		p.handleGetBalance(req)
+		return nil
+	case operationCredit:
+		p.handleCredit(req)
+		return nil
+	case operationDebit:
+		p.handleDebit(req)
+		return nil
+	case operationTransfer:
+		p.handleTransfer(req)
+		return nil
+	default:
+		p.deliverError(req, errorCodeInvalidArg, fmt.Sprintf("unknown operation: %s", req.Type), nil)
+		return nil
+	}
+}
+
+func (p *Plugin) handleGetBalance(req *framework.PluginRequest) {
+	var payload getBalanceRequest
+	if !p.parseRequest(req, &payload) {
+		return
+	}
+
+	payload.Channel = normalizeChannel(payload.Channel)
+	payload.Username = normalizeUsername(payload.Username)
+
+	if payload.Channel == "" {
+		p.deliverError(req, errorCodeInvalidArg, "missing field channel", map[string]interface{}{"field": "channel"})
+		return
+	}
+
+	if payload.Username == "" {
+		p.deliverError(req, errorCodeInvalidArg, "missing field username", map[string]interface{}{"field": "username"})
+		return
+	}
+
+	result, err := p.store.GetBalance(p.operationContext(), payload.Channel, payload.Username)
+	if p.deliverStoreError(req, operationGetBalance, err) {
+		return
+	}
+
+	if !result.OK {
+		p.deliverOperationError(req, result.ErrorCode, operationGetBalance)
+		return
+	}
+
+	p.deliverSuccess(req, map[string]interface{}{
+		"channel":  payload.Channel,
+		"username": payload.Username,
+		"balance":  result.Balance,
+	})
+}
+
+func (p *Plugin) handleCredit(req *framework.PluginRequest) {
+	var payload creditRequest
+	if !p.parseRequest(req, &payload) {
+		return
+	}
+
+	payload.Channel = normalizeChannel(payload.Channel)
+	payload.Username = normalizeUsername(payload.Username)
+	payload.IdempotencyKey = normalizeOptional(payload.IdempotencyKey)
+	payload.Reason = normalizeOptional(payload.Reason)
+
+	if payload.Channel == "" {
+		p.deliverError(req, errorCodeInvalidArg, "missing field channel", map[string]interface{}{"field": "channel"})
+		return
+	}
+
+	if payload.Username == "" {
+		p.deliverError(req, errorCodeInvalidArg, "missing field username", map[string]interface{}{"field": "username"})
+		return
+	}
+
+	if payload.Amount <= 0 {
+		p.deliverError(req, errorCodeInvalidAmount, "amount must be greater than 0", map[string]interface{}{"field": "amount"})
+		return
+	}
+
+	if payload.IdempotencyKey == "" {
+		payload.IdempotencyKey = req.ID
+	}
+
+	result, err := p.store.Credit(
+		p.operationContext(),
+		payload.Channel,
+		payload.Username,
+		payload.Amount,
+		payload.IdempotencyKey,
+		normalizeOptional(req.From),
+		payload.Reason,
+		payload.Metadata,
+	)
+	if p.deliverStoreError(req, operationCredit, err) {
+		return
+	}
+
+	if !result.OK {
+		p.deliverOperationError(req, result.ErrorCode, operationCredit)
+		return
+	}
+
+	p.deliverSuccess(req, map[string]interface{}{
+		"channel":         payload.Channel,
+		"username":        payload.Username,
+		"amount":          payload.Amount,
+		"balance_before":  result.Balance - payload.Amount,
+		"balance_after":   result.Balance,
+		"idempotency_key": payload.IdempotencyKey,
+		"already_applied": result.AlreadyApplied,
+	})
+}
+
+func (p *Plugin) handleDebit(req *framework.PluginRequest) {
+	var payload debitRequest
+	if !p.parseRequest(req, &payload) {
+		return
+	}
+
+	payload.Channel = normalizeChannel(payload.Channel)
+	payload.Username = normalizeUsername(payload.Username)
+	payload.IdempotencyKey = normalizeOptional(payload.IdempotencyKey)
+	payload.Reason = normalizeOptional(payload.Reason)
+
+	if payload.Channel == "" {
+		p.deliverError(req, errorCodeInvalidArg, "missing field channel", map[string]interface{}{"field": "channel"})
+		return
+	}
+
+	if payload.Username == "" {
+		p.deliverError(req, errorCodeInvalidArg, "missing field username", map[string]interface{}{"field": "username"})
+		return
+	}
+
+	if payload.Amount <= 0 {
+		p.deliverError(req, errorCodeInvalidAmount, "amount must be greater than 0", map[string]interface{}{"field": "amount"})
+		return
+	}
+
+	if payload.IdempotencyKey == "" {
+		payload.IdempotencyKey = req.ID
+	}
+
+	result, err := p.store.Debit(
+		p.operationContext(),
+		payload.Channel,
+		payload.Username,
+		payload.Amount,
+		payload.IdempotencyKey,
+		normalizeOptional(req.From),
+		payload.Reason,
+		payload.Metadata,
+	)
+	if p.deliverStoreError(req, operationDebit, err) {
+		return
+	}
+
+	if !result.OK {
+		p.deliverOperationError(req, result.ErrorCode, operationDebit)
+		return
+	}
+
+	p.deliverSuccess(req, map[string]interface{}{
+		"channel":         payload.Channel,
+		"username":        payload.Username,
+		"amount":          payload.Amount,
+		"balance_before":  result.Balance + payload.Amount,
+		"balance_after":   result.Balance,
+		"idempotency_key": payload.IdempotencyKey,
+		"already_applied": result.AlreadyApplied,
+	})
+}
+
+func (p *Plugin) handleTransfer(req *framework.PluginRequest) {
+	var payload transferRequest
+	if !p.parseRequest(req, &payload) {
+		return
+	}
+
+	payload.Channel = normalizeChannel(payload.Channel)
+	payload.FromUsername = normalizeUsername(payload.FromUsername)
+	payload.ToUsername = normalizeUsername(payload.ToUsername)
+	payload.IdempotencyKey = normalizeOptional(payload.IdempotencyKey)
+	payload.Reason = normalizeOptional(payload.Reason)
+
+	if payload.Channel == "" {
+		p.deliverError(req, errorCodeInvalidArg, "missing field channel", map[string]interface{}{"field": "channel"})
+		return
+	}
+
+	if payload.FromUsername == "" {
+		p.deliverError(req, errorCodeInvalidArg, "missing field from_username", map[string]interface{}{"field": "from_username"})
+		return
+	}
+
+	if payload.ToUsername == "" {
+		p.deliverError(req, errorCodeInvalidArg, "missing field to_username", map[string]interface{}{"field": "to_username"})
+		return
+	}
+
+	if payload.Amount <= 0 {
+		p.deliverError(req, errorCodeInvalidAmount, "amount must be greater than 0", map[string]interface{}{"field": "amount"})
+		return
+	}
+
+	if payload.IdempotencyKey == "" {
+		payload.IdempotencyKey = req.ID
+	}
+
+	result, err := p.store.Transfer(
+		p.operationContext(),
+		payload.Channel,
+		payload.FromUsername,
+		payload.ToUsername,
+		payload.Amount,
+		payload.IdempotencyKey,
+		normalizeOptional(req.From),
+		payload.Reason,
+		payload.Metadata,
+	)
+	if p.deliverStoreError(req, operationTransfer, err) {
+		return
+	}
+
+	if !result.OK {
+		p.deliverOperationError(req, result.ErrorCode, operationTransfer)
+		return
+	}
+
+	p.deliverSuccess(req, map[string]interface{}{
+		"channel":             payload.Channel,
+		"from_username":       payload.FromUsername,
+		"to_username":         payload.ToUsername,
+		"amount":              payload.Amount,
+		"from_balance_before": result.FromBalance + payload.Amount,
+		"from_balance_after":  result.FromBalance,
+		"to_balance_before":   result.ToBalance - payload.Amount,
+		"to_balance_after":    result.ToBalance,
+		"idempotency_key":     payload.IdempotencyKey,
+		"already_applied":     result.AlreadyApplied,
+	})
+}
+
+func (p *Plugin) parseRequest(req *framework.PluginRequest, payload interface{}) bool {
+	if req.Data == nil || len(req.Data.RawJSON) == 0 {
+		p.deliverError(req, errorCodeInvalidArg, "missing data.raw_json", map[string]interface{}{"field": "data.raw_json"})
+		return false
+	}
+
+	if err := json.Unmarshal(req.Data.RawJSON, payload); err != nil {
+		p.deliverError(req, errorCodeInvalidArg, "invalid request payload", nil)
+		return false
+	}
+
+	return true
+}
+
+func (p *Plugin) operationContext() context.Context {
+	if p.ctx != nil {
+		return p.ctx
+	}
+
+	return context.Background()
+}
+
+func (p *Plugin) deliverStoreError(req *framework.PluginRequest, operation string, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errorCode := mapStoreErrorCode(err)
+	p.deliverError(req, errorCode, operationErrorMessage(errorCode, operation), nil)
+	return true
+}
+
+func (p *Plugin) deliverOperationError(req *framework.PluginRequest, errorCode string, operation string) {
+	if errorCode == "" {
+		errorCode = errorCodeDBError
+	}
+
+	p.deliverError(req, errorCode, operationErrorMessage(errorCode, operation), nil)
+}
+
+func (p *Plugin) deliverSuccess(req *framework.PluginRequest, payload map[string]interface{}) {
+	rawJSON, err := json.Marshal(payload)
+	if err != nil {
+		p.deliverError(req, errorCodeInternal, "failed to marshal response payload", nil)
+		return
+	}
+
+	resp := &framework.EventData{
+		PluginResponse: &framework.PluginResponse{
+			ID:      req.ID,
+			From:    pluginName,
+			Success: true,
+			Data: &framework.ResponseData{
+				RawJSON: rawJSON,
+			},
+		},
+	}
+
+	p.eventBus.DeliverResponse(req.ID, resp, nil)
+}
+
+func normalizeChannel(channel string) string {
+	return strings.TrimSpace(channel)
+}
+
+func normalizeUsername(username string) string {
+	return strings.ToLower(strings.TrimSpace(username))
+}
+
+func normalizeOptional(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func operationErrorMessage(errorCode, operation string) string {
+	switch errorCode {
+	case errorCodeInvalidArg:
+		return "invalid argument"
+	case errorCodeInvalidAmount:
+		return "invalid amount"
+	case errorCodeInsufficient:
+		return "insufficient funds"
+	case errorCodeIdempotency:
+		return "idempotency conflict"
+	case errorCodeDBUnavailable:
+		return "database unavailable"
+	case errorCodeDBError:
+		return "database error"
+	case errorCodeInternal:
+		return "internal error"
+	default:
+		return fmt.Sprintf(nilResponseErrorTemplate, operation)
+	}
+}
+
+func (p *Plugin) deliverError(req *framework.PluginRequest, errorCode, message string, details map[string]interface{}) {
+	errorPayload := map[string]interface{}{
+		"error_code": errorCode,
+		"message":    message,
+	}
+	if details != nil {
+		errorPayload["details"] = details
+	}
+
+	rawJSON, err := json.Marshal(errorPayload)
+	if err != nil {
+		rawJSON = []byte(`{"error_code":"INTERNAL","message":"failed to marshal error payload"}`)
+		message = "failed to marshal error payload"
+	}
+
+	resp := &framework.EventData{
+		PluginResponse: &framework.PluginResponse{
+			ID:      req.ID,
+			From:    pluginName,
+			Success: false,
+			Error:   message,
+			Data: &framework.ResponseData{
+				RawJSON: rawJSON,
+			},
+		},
+	}
+
+	p.eventBus.DeliverResponse(req.ID, resp, nil)
+}

--- a/internal/plugins/economy/plugin_test.go
+++ b/internal/plugins/economy/plugin_test.go
@@ -1,0 +1,538 @@
+package economy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/hildolfr/daz/internal/framework"
+	"github.com/hildolfr/daz/pkg/eventbus"
+)
+
+type mockDelivery struct {
+	correlationID string
+	response      *framework.EventData
+	err           error
+}
+
+type mockEventBus struct {
+	mu          sync.Mutex
+	subscribers map[string][]framework.EventHandler
+	deliveries  []mockDelivery
+}
+
+func newMockEventBus() *mockEventBus {
+	return &mockEventBus{subscribers: make(map[string][]framework.EventHandler)}
+}
+
+func (m *mockEventBus) Broadcast(eventType string, data *framework.EventData) error {
+	_ = eventType
+	_ = data
+	return nil
+}
+
+func (m *mockEventBus) BroadcastWithMetadata(eventType string, data *framework.EventData, metadata *framework.EventMetadata) error {
+	_ = metadata
+	return m.Broadcast(eventType, data)
+}
+
+func (m *mockEventBus) Send(target string, eventType string, data *framework.EventData) error {
+	_ = target
+	_ = eventType
+	_ = data
+	return nil
+}
+
+func (m *mockEventBus) SendWithMetadata(target string, eventType string, data *framework.EventData, metadata *framework.EventMetadata) error {
+	_ = metadata
+	return m.Send(target, eventType, data)
+}
+
+func (m *mockEventBus) Request(ctx context.Context, target string, eventType string, data *framework.EventData, metadata *framework.EventMetadata) (*framework.EventData, error) {
+	_ = ctx
+	_ = target
+	_ = eventType
+	_ = data
+	_ = metadata
+	return nil, nil
+}
+
+func (m *mockEventBus) DeliverResponse(correlationID string, response *framework.EventData, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deliveries = append(m.deliveries, mockDelivery{correlationID: correlationID, response: response, err: err})
+}
+
+func (m *mockEventBus) Subscribe(eventType string, handler framework.EventHandler) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.subscribers[eventType] = append(m.subscribers[eventType], handler)
+	return nil
+}
+
+func (m *mockEventBus) SubscribeWithTags(pattern string, handler framework.EventHandler, tags []string) error {
+	_ = tags
+	return m.Subscribe(pattern, handler)
+}
+
+func (m *mockEventBus) RegisterPlugin(name string, plugin framework.Plugin) error {
+	_ = name
+	_ = plugin
+	return nil
+}
+
+func (m *mockEventBus) UnregisterPlugin(name string) error {
+	_ = name
+	return nil
+}
+
+func (m *mockEventBus) GetDroppedEventCounts() map[string]int64 {
+	return map[string]int64{}
+}
+
+func (m *mockEventBus) GetDroppedEventCount(eventType string) int64 {
+	_ = eventType
+	return 0
+}
+
+type stubStore struct {
+	getBalanceFn func(ctx context.Context, channel, username string) (GetBalanceResult, error)
+	creditFn     func(ctx context.Context, channel, username string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (CreditResult, error)
+	debitFn      func(ctx context.Context, channel, username string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (DebitResult, error)
+	transferFn   func(ctx context.Context, channel, fromUsername, toUsername string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (TransferResult, error)
+}
+
+func (s *stubStore) GetBalance(ctx context.Context, channel, username string) (GetBalanceResult, error) {
+	if s.getBalanceFn == nil {
+		panic("unexpected GetBalance call")
+	}
+	return s.getBalanceFn(ctx, channel, username)
+}
+
+func (s *stubStore) Credit(ctx context.Context, channel, username string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (CreditResult, error) {
+	if s.creditFn == nil {
+		panic("unexpected Credit call")
+	}
+	return s.creditFn(ctx, channel, username, amount, idempotencyKey, actor, reason, metadata)
+}
+
+func (s *stubStore) Debit(ctx context.Context, channel, username string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (DebitResult, error) {
+	if s.debitFn == nil {
+		panic("unexpected Debit call")
+	}
+	return s.debitFn(ctx, channel, username, amount, idempotencyKey, actor, reason, metadata)
+}
+
+func (s *stubStore) Transfer(ctx context.Context, channel, fromUsername, toUsername string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (TransferResult, error) {
+	if s.transferFn == nil {
+		panic("unexpected Transfer call")
+	}
+	return s.transferFn(ctx, channel, fromUsername, toUsername, amount, idempotencyKey, actor, reason, metadata)
+}
+
+func TestEconomyPlugin_IgnoresOtherTargets(t *testing.T) {
+	pl, bus := setupStartedPlugin(t, &stubStore{})
+
+	event := framework.NewDataEvent(eventbus.EventPluginRequest, &framework.EventData{
+		PluginRequest: &framework.PluginRequest{
+			ID:   "req-1",
+			From: "tester",
+			To:   "not-economy",
+			Type: operationGetBalance,
+		},
+	})
+
+	handler := getPluginRequestHandler(t, bus)
+	if err := handler(event); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if len(bus.deliveries) != 0 {
+		t.Fatalf("expected no DeliverResponse calls, got %d", len(bus.deliveries))
+	}
+
+	if pl.Name() != pluginName {
+		t.Fatalf("unexpected plugin name: %s", pl.Name())
+	}
+}
+
+func TestEconomyPlugin_RejectsMissingCorrelation(t *testing.T) {
+	_, bus := setupStartedPlugin(t, &stubStore{})
+
+	event := framework.NewDataEvent(eventbus.EventPluginRequest, &framework.EventData{
+		PluginRequest: &framework.PluginRequest{
+			ID:   "",
+			From: "tester",
+			To:   pluginName,
+			Type: operationGetBalance,
+		},
+	})
+
+	handler := getPluginRequestHandler(t, bus)
+	if err := handler(event); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if len(bus.deliveries) != 0 {
+		t.Fatalf("expected no DeliverResponse calls for missing correlation ID, got %d", len(bus.deliveries))
+	}
+}
+
+func TestEconomyPlugin_UnknownOperationDeliversError(t *testing.T) {
+	_, bus := setupStartedPlugin(t, &stubStore{})
+
+	requestID := "req-unknown-op"
+	delivery := performRequest(t, bus, requestID, "economy.does_not_exist", map[string]interface{}{})
+
+	if delivery.correlationID != requestID {
+		t.Fatalf("expected correlation ID %q, got %q", requestID, delivery.correlationID)
+	}
+
+	if getErrorCode(t, delivery) != errorCodeInvalidArg {
+		t.Fatalf("expected INVALID_ARGUMENT, got %s", getErrorCode(t, delivery))
+	}
+}
+
+func TestEconomyPlugin_GetBalanceSuccess(t *testing.T) {
+	store := &stubStore{
+		getBalanceFn: func(ctx context.Context, channel, username string) (GetBalanceResult, error) {
+			if channel != "room-a" {
+				t.Fatalf("expected normalized channel room-a, got %q", channel)
+			}
+			if username != "alice" {
+				t.Fatalf("expected normalized username alice, got %q", username)
+			}
+			return GetBalanceResult{OK: true, Balance: 1250}, nil
+		},
+	}
+
+	_, bus := setupStartedPlugin(t, store)
+	delivery := performRequest(t, bus, "bal-1", operationGetBalance, map[string]interface{}{
+		"channel":  " room-a ",
+		"username": " Alice ",
+	})
+
+	payload := getRawPayload(t, delivery)
+	if payload["balance"].(float64) != 1250 {
+		t.Fatalf("expected balance 1250, got %#v", payload["balance"])
+	}
+	if payload["channel"].(string) != "room-a" {
+		t.Fatalf("expected channel room-a, got %#v", payload["channel"])
+	}
+	if payload["username"].(string) != "alice" {
+		t.Fatalf("expected username alice, got %#v", payload["username"])
+	}
+}
+
+func TestEconomyPlugin_CreditSuccess(t *testing.T) {
+	store := &stubStore{
+		creditFn: func(ctx context.Context, channel, username string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (CreditResult, error) {
+			if channel != "room-a" || username != "alice" || amount != 250 {
+				t.Fatalf("unexpected credit args: %q %q %d", channel, username, amount)
+			}
+			if idempotencyKey != "cred-1" {
+				t.Fatalf("expected fallback idempotency key cred-1, got %q", idempotencyKey)
+			}
+			if actor != "tester" {
+				t.Fatalf("expected actor tester, got %q", actor)
+			}
+			if reason != "daily" {
+				t.Fatalf("expected reason daily, got %q", reason)
+			}
+			if metadata["source"].(string) != "rewards" {
+				t.Fatalf("unexpected metadata: %#v", metadata)
+			}
+			return CreditResult{OK: true, Balance: 1500, AlreadyApplied: false}, nil
+		},
+	}
+
+	_, bus := setupStartedPlugin(t, store)
+	delivery := performRequest(t, bus, "cred-1", operationCredit, map[string]interface{}{
+		"channel":  "room-a",
+		"username": "alice",
+		"amount":   250,
+		"reason":   "daily",
+		"metadata": map[string]interface{}{"source": "rewards"},
+	})
+
+	payload := getRawPayload(t, delivery)
+	if payload["balance_before"].(float64) != 1250 || payload["balance_after"].(float64) != 1500 {
+		t.Fatalf("unexpected credit balances: %#v", payload)
+	}
+	if payload["idempotency_key"].(string) != "cred-1" {
+		t.Fatalf("expected idempotency key cred-1, got %#v", payload["idempotency_key"])
+	}
+}
+
+func TestEconomyPlugin_DebitSuccess(t *testing.T) {
+	store := &stubStore{
+		debitFn: func(ctx context.Context, channel, username string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (DebitResult, error) {
+			if idempotencyKey != "debit-key" {
+				t.Fatalf("expected request idempotency key, got %q", idempotencyKey)
+			}
+			return DebitResult{OK: true, Balance: 700, AlreadyApplied: false}, nil
+		},
+	}
+
+	_, bus := setupStartedPlugin(t, store)
+	delivery := performRequest(t, bus, "deb-1", operationDebit, map[string]interface{}{
+		"channel":         "room-a",
+		"username":        "alice",
+		"amount":          300,
+		"idempotency_key": "debit-key",
+	})
+
+	payload := getRawPayload(t, delivery)
+	if payload["balance_before"].(float64) != 1000 || payload["balance_after"].(float64) != 700 {
+		t.Fatalf("unexpected debit balances: %#v", payload)
+	}
+}
+
+func TestEconomyPlugin_TransferSuccess(t *testing.T) {
+	store := &stubStore{
+		transferFn: func(ctx context.Context, channel, fromUsername, toUsername string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (TransferResult, error) {
+			if fromUsername != "alice" || toUsername != "bob" || amount != 50 {
+				t.Fatalf("unexpected transfer args: %q %q %d", fromUsername, toUsername, amount)
+			}
+			return TransferResult{OK: true, FromBalance: 1450, ToBalance: 70, AlreadyApplied: false}, nil
+		},
+	}
+
+	_, bus := setupStartedPlugin(t, store)
+	delivery := performRequest(t, bus, "xfer-1", operationTransfer, map[string]interface{}{
+		"channel":       "room-a",
+		"from_username": "Alice",
+		"to_username":   "Bob",
+		"amount":        50,
+	})
+
+	payload := getRawPayload(t, delivery)
+	if payload["from_balance_before"].(float64) != 1500 || payload["from_balance_after"].(float64) != 1450 {
+		t.Fatalf("unexpected from balances: %#v", payload)
+	}
+	if payload["to_balance_before"].(float64) != 20 || payload["to_balance_after"].(float64) != 70 {
+		t.Fatalf("unexpected to balances: %#v", payload)
+	}
+}
+
+func TestEconomyPlugin_InvalidJSONReturnsInvalidArgument(t *testing.T) {
+	_, bus := setupStartedPlugin(t, &stubStore{})
+
+	operations := []string{operationGetBalance, operationCredit, operationDebit, operationTransfer}
+	for _, operation := range operations {
+		t.Run(operation, func(t *testing.T) {
+			delivery := performRequestRaw(t, bus, fmt.Sprintf("bad-json-%s", operation), operation, []byte("{"))
+			if getErrorCode(t, delivery) != errorCodeInvalidArg {
+				t.Fatalf("expected INVALID_ARGUMENT, got %s", getErrorCode(t, delivery))
+			}
+		})
+	}
+}
+
+func TestEconomyPlugin_MissingFieldsReturnInvalidArgument(t *testing.T) {
+	tests := []struct {
+		name      string
+		op        string
+		payload   map[string]interface{}
+		errorCode string
+	}{
+		{name: "get_balance_missing_username", op: operationGetBalance, payload: map[string]interface{}{"channel": "room-a"}, errorCode: errorCodeInvalidArg},
+		{name: "credit_missing_channel", op: operationCredit, payload: map[string]interface{}{"username": "alice", "amount": 5}, errorCode: errorCodeInvalidArg},
+		{name: "debit_missing_username", op: operationDebit, payload: map[string]interface{}{"channel": "room-a", "amount": 5}, errorCode: errorCodeInvalidArg},
+		{name: "transfer_missing_to", op: operationTransfer, payload: map[string]interface{}{"channel": "room-a", "from_username": "alice", "amount": 5}, errorCode: errorCodeInvalidArg},
+	}
+
+	_, bus := setupStartedPlugin(t, &stubStore{})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			delivery := performRequest(t, bus, tt.name, tt.op, tt.payload)
+			if getErrorCode(t, delivery) != tt.errorCode {
+				t.Fatalf("expected %s, got %s", tt.errorCode, getErrorCode(t, delivery))
+			}
+		})
+	}
+}
+
+func TestEconomyPlugin_InvalidAmountReturnsInvalidAmount(t *testing.T) {
+	_, bus := setupStartedPlugin(t, &stubStore{})
+
+	invalidAmountCases := []struct {
+		name    string
+		op      string
+		payload map[string]interface{}
+	}{
+		{name: "credit", op: operationCredit, payload: map[string]interface{}{"channel": "room-a", "username": "alice", "amount": 0}},
+		{name: "debit", op: operationDebit, payload: map[string]interface{}{"channel": "room-a", "username": "alice", "amount": -1}},
+		{name: "transfer", op: operationTransfer, payload: map[string]interface{}{"channel": "room-a", "from_username": "alice", "to_username": "bob", "amount": 0}},
+	}
+
+	for _, tc := range invalidAmountCases {
+		t.Run(tc.name, func(t *testing.T) {
+			delivery := performRequest(t, bus, tc.name, tc.op, tc.payload)
+			if getErrorCode(t, delivery) != errorCodeInvalidAmount {
+				t.Fatalf("expected INVALID_AMOUNT, got %s", getErrorCode(t, delivery))
+			}
+		})
+	}
+}
+
+func TestEconomyPlugin_InsufficientFundsMapping(t *testing.T) {
+	store := &stubStore{
+		debitFn: func(ctx context.Context, channel, username string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (DebitResult, error) {
+			return DebitResult{OK: false, ErrorCode: errorCodeInsufficient}, nil
+		},
+		transferFn: func(ctx context.Context, channel, fromUsername, toUsername string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (TransferResult, error) {
+			return TransferResult{OK: false, ErrorCode: errorCodeInsufficient}, nil
+		},
+	}
+
+	_, bus := setupStartedPlugin(t, store)
+
+	debitDelivery := performRequest(t, bus, "deb-ins", operationDebit, map[string]interface{}{"channel": "room-a", "username": "alice", "amount": 10})
+	if getErrorCode(t, debitDelivery) != errorCodeInsufficient {
+		t.Fatalf("expected INSUFFICIENT_FUNDS, got %s", getErrorCode(t, debitDelivery))
+	}
+
+	transferDelivery := performRequest(t, bus, "xfer-ins", operationTransfer, map[string]interface{}{"channel": "room-a", "from_username": "alice", "to_username": "bob", "amount": 10})
+	if getErrorCode(t, transferDelivery) != errorCodeInsufficient {
+		t.Fatalf("expected INSUFFICIENT_FUNDS, got %s", getErrorCode(t, transferDelivery))
+	}
+}
+
+func TestEconomyPlugin_IdempotencyConflictMapping(t *testing.T) {
+	store := &stubStore{
+		creditFn: func(ctx context.Context, channel, username string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (CreditResult, error) {
+			return CreditResult{OK: false, ErrorCode: errorCodeIdempotency}, nil
+		},
+		debitFn: func(ctx context.Context, channel, username string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (DebitResult, error) {
+			return DebitResult{OK: false, ErrorCode: errorCodeIdempotency}, nil
+		},
+		transferFn: func(ctx context.Context, channel, fromUsername, toUsername string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (TransferResult, error) {
+			return TransferResult{OK: false, ErrorCode: errorCodeIdempotency}, nil
+		},
+	}
+
+	_, bus := setupStartedPlugin(t, store)
+
+	creditDelivery := performRequest(t, bus, "cred-conflict", operationCredit, map[string]interface{}{"channel": "room-a", "username": "alice", "amount": 1})
+	if getErrorCode(t, creditDelivery) != errorCodeIdempotency {
+		t.Fatalf("expected IDEMPOTENCY_CONFLICT, got %s", getErrorCode(t, creditDelivery))
+	}
+
+	debitDelivery := performRequest(t, bus, "deb-conflict", operationDebit, map[string]interface{}{"channel": "room-a", "username": "alice", "amount": 1})
+	if getErrorCode(t, debitDelivery) != errorCodeIdempotency {
+		t.Fatalf("expected IDEMPOTENCY_CONFLICT, got %s", getErrorCode(t, debitDelivery))
+	}
+
+	transferDelivery := performRequest(t, bus, "xfer-conflict", operationTransfer, map[string]interface{}{"channel": "room-a", "from_username": "alice", "to_username": "bob", "amount": 1})
+	if getErrorCode(t, transferDelivery) != errorCodeIdempotency {
+		t.Fatalf("expected IDEMPOTENCY_CONFLICT, got %s", getErrorCode(t, transferDelivery))
+	}
+}
+
+func setupStartedPlugin(t *testing.T, store Store) (*Plugin, *mockEventBus) {
+	t.Helper()
+
+	plugin, ok := New().(*Plugin)
+	if !ok {
+		t.Fatalf("unexpected plugin type: %T", New())
+	}
+
+	if store != nil {
+		plugin.store = store
+	}
+
+	bus := newMockEventBus()
+	if err := plugin.Init(nil, bus); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	if err := plugin.Start(); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	return plugin, bus
+}
+
+func getPluginRequestHandler(t *testing.T, bus *mockEventBus) framework.EventHandler {
+	t.Helper()
+
+	handlers := bus.subscribers[eventbus.EventPluginRequest]
+	if len(handlers) != 1 {
+		t.Fatalf("expected exactly one plugin.request handler, got %d", len(handlers))
+	}
+
+	return handlers[0]
+}
+
+func performRequest(t *testing.T, bus *mockEventBus, id, operation string, payload map[string]interface{}) mockDelivery {
+	t.Helper()
+
+	rawPayload, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	return performRequestRaw(t, bus, id, operation, rawPayload)
+}
+
+func performRequestRaw(t *testing.T, bus *mockEventBus, id, operation string, rawPayload []byte) mockDelivery {
+	t.Helper()
+
+	event := framework.NewDataEvent(eventbus.EventPluginRequest, &framework.EventData{
+		PluginRequest: &framework.PluginRequest{
+			ID:   id,
+			From: "tester",
+			To:   pluginName,
+			Type: operation,
+			Data: &framework.RequestData{RawJSON: rawPayload},
+		},
+	})
+
+	handler := getPluginRequestHandler(t, bus)
+	if err := handler(event); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if len(bus.deliveries) == 0 {
+		t.Fatalf("expected one delivery for %s", operation)
+	}
+
+	return bus.deliveries[len(bus.deliveries)-1]
+}
+
+func getRawPayload(t *testing.T, delivery mockDelivery) map[string]interface{} {
+	t.Helper()
+
+	if delivery.err != nil {
+		t.Fatalf("expected nil delivery error, got %v", delivery.err)
+	}
+	if delivery.response == nil || delivery.response.PluginResponse == nil {
+		t.Fatal("missing plugin response")
+	}
+
+	resp := delivery.response.PluginResponse
+	if resp.Data == nil || len(resp.Data.RawJSON) == 0 {
+		t.Fatal("missing response data.raw_json")
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(resp.Data.RawJSON, &payload); err != nil {
+		t.Fatalf("unmarshal response payload: %v", err)
+	}
+
+	return payload
+}
+
+func getErrorCode(t *testing.T, delivery mockDelivery) string {
+	t.Helper()
+	payload := getRawPayload(t, delivery)
+
+	errorCode, ok := payload["error_code"].(string)
+	if !ok {
+		t.Fatalf("error payload missing error_code: %#v", payload)
+	}
+
+	return errorCode
+}

--- a/internal/plugins/economy/store.go
+++ b/internal/plugins/economy/store.go
@@ -1,0 +1,257 @@
+package economy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hildolfr/daz/internal/framework"
+)
+
+const (
+	queryGetBalance = "SELECT * FROM daz_economy_get_balance($1,$2)"
+	queryCredit     = "SELECT * FROM daz_economy_credit($1,$2,$3,$4,$5,$6,$7)"
+	queryDebit      = "SELECT * FROM daz_economy_debit($1,$2,$3,$4,$5,$6,$7)"
+	queryTransfer   = "SELECT * FROM daz_economy_transfer($1,$2,$3,$4,$5,$6,$7,$8)"
+)
+
+type Store interface {
+	GetBalance(ctx context.Context, channel, username string) (GetBalanceResult, error)
+	Credit(ctx context.Context, channel, username string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (CreditResult, error)
+	Debit(ctx context.Context, channel, username string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (DebitResult, error)
+	Transfer(ctx context.Context, channel, fromUsername, toUsername string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (TransferResult, error)
+}
+
+type GetBalanceResult struct {
+	OK        bool
+	ErrorCode string
+	Balance   int64
+}
+
+type CreditResult struct {
+	OK             bool
+	ErrorCode      string
+	Balance        int64
+	LedgerID       int64
+	AlreadyApplied bool
+}
+
+type DebitResult struct {
+	OK             bool
+	ErrorCode      string
+	Balance        int64
+	LedgerID       int64
+	AlreadyApplied bool
+}
+
+type TransferResult struct {
+	OK             bool
+	ErrorCode      string
+	FromBalance    int64
+	ToBalance      int64
+	LedgerID       int64
+	AlreadyApplied bool
+}
+
+type StoreError struct {
+	Code string
+	Err  error
+}
+
+func (e *StoreError) Error() string {
+	if e == nil {
+		return ""
+	}
+
+	if e.Err == nil {
+		return e.Code
+	}
+
+	return fmt.Sprintf("%s: %v", e.Code, e.Err)
+}
+
+func (e *StoreError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+
+	return e.Err
+}
+
+type sqlStore struct {
+	helper *framework.SQLRequestHelper
+}
+
+func NewSQLStore(helper *framework.SQLRequestHelper) Store {
+	return &sqlStore{helper: helper}
+}
+
+func (s *sqlStore) GetBalance(ctx context.Context, channel, username string) (GetBalanceResult, error) {
+	rows, err := s.query(ctx, queryGetBalance, channel, username)
+	if err != nil {
+		return GetBalanceResult{}, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	if !rows.Next() {
+		return GetBalanceResult{}, &StoreError{Code: errorCodeDBError, Err: errors.New("daz_economy_get_balance returned no rows")}
+	}
+
+	var ok bool
+	var errorCode *string
+	var balance int64
+	if err := rows.Scan(&ok, &errorCode, &balance); err != nil {
+		return GetBalanceResult{}, &StoreError{Code: errorCodeDBError, Err: fmt.Errorf("failed to scan daz_economy_get_balance row: %w", err)}
+	}
+
+	return GetBalanceResult{
+		OK:        ok,
+		ErrorCode: stringOrEmpty(errorCode),
+		Balance:   balance,
+	}, nil
+}
+
+func (s *sqlStore) Credit(ctx context.Context, channel, username string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (CreditResult, error) {
+	rows, err := s.query(ctx, queryCredit, channel, username, amount, idempotencyKey, actor, reason, metadata)
+	if err != nil {
+		return CreditResult{}, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	if !rows.Next() {
+		return CreditResult{}, &StoreError{Code: errorCodeDBError, Err: errors.New("daz_economy_credit returned no rows")}
+	}
+
+	var ok bool
+	var errorCode *string
+	var balance int64
+	var ledgerID *int64
+	var alreadyApplied bool
+	if err := rows.Scan(&ok, &errorCode, &balance, &ledgerID, &alreadyApplied); err != nil {
+		return CreditResult{}, &StoreError{Code: errorCodeDBError, Err: fmt.Errorf("failed to scan daz_economy_credit row: %w", err)}
+	}
+
+	return CreditResult{
+		OK:             ok,
+		ErrorCode:      stringOrEmpty(errorCode),
+		Balance:        balance,
+		LedgerID:       int64OrZero(ledgerID),
+		AlreadyApplied: alreadyApplied,
+	}, nil
+}
+
+func (s *sqlStore) Debit(ctx context.Context, channel, username string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (DebitResult, error) {
+	rows, err := s.query(ctx, queryDebit, channel, username, amount, idempotencyKey, actor, reason, metadata)
+	if err != nil {
+		return DebitResult{}, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	if !rows.Next() {
+		return DebitResult{}, &StoreError{Code: errorCodeDBError, Err: errors.New("daz_economy_debit returned no rows")}
+	}
+
+	var ok bool
+	var errorCode *string
+	var balance int64
+	var ledgerID *int64
+	var alreadyApplied bool
+	if err := rows.Scan(&ok, &errorCode, &balance, &ledgerID, &alreadyApplied); err != nil {
+		return DebitResult{}, &StoreError{Code: errorCodeDBError, Err: fmt.Errorf("failed to scan daz_economy_debit row: %w", err)}
+	}
+
+	return DebitResult{
+		OK:             ok,
+		ErrorCode:      stringOrEmpty(errorCode),
+		Balance:        balance,
+		LedgerID:       int64OrZero(ledgerID),
+		AlreadyApplied: alreadyApplied,
+	}, nil
+}
+
+func (s *sqlStore) Transfer(ctx context.Context, channel, fromUsername, toUsername string, amount int64, idempotencyKey, actor, reason string, metadata map[string]interface{}) (TransferResult, error) {
+	rows, err := s.query(ctx, queryTransfer, channel, fromUsername, toUsername, amount, idempotencyKey, actor, reason, metadata)
+	if err != nil {
+		return TransferResult{}, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	if !rows.Next() {
+		return TransferResult{}, &StoreError{Code: errorCodeDBError, Err: errors.New("daz_economy_transfer returned no rows")}
+	}
+
+	var ok bool
+	var errorCode *string
+	var fromBalance int64
+	var toBalance int64
+	var ledgerID *int64
+	var alreadyApplied bool
+	if err := rows.Scan(&ok, &errorCode, &fromBalance, &toBalance, &ledgerID, &alreadyApplied); err != nil {
+		return TransferResult{}, &StoreError{Code: errorCodeDBError, Err: fmt.Errorf("failed to scan daz_economy_transfer row: %w", err)}
+	}
+
+	return TransferResult{
+		OK:             ok,
+		ErrorCode:      stringOrEmpty(errorCode),
+		FromBalance:    fromBalance,
+		ToBalance:      toBalance,
+		LedgerID:       int64OrZero(ledgerID),
+		AlreadyApplied: alreadyApplied,
+	}, nil
+}
+
+func (s *sqlStore) query(ctx context.Context, query string, args ...interface{}) (*framework.QueryRows, error) {
+	if s.helper == nil {
+		return nil, &StoreError{Code: errorCodeDBUnavailable, Err: errors.New("sql helper not configured")}
+	}
+
+	rows, err := s.helper.NormalQuery(ctx, query, args...)
+	if err != nil {
+		return nil, mapSQLRequestError(err)
+	}
+
+	return rows, nil
+}
+
+func mapSQLRequestError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	lowerErr := strings.ToLower(err.Error())
+	if strings.Contains(lowerErr, "query failed:") || strings.Contains(lowerErr, "scan") {
+		return &StoreError{Code: errorCodeDBError, Err: err}
+	}
+
+	return &StoreError{Code: errorCodeDBUnavailable, Err: err}
+}
+
+func mapStoreErrorCode(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var storeErr *StoreError
+	if errors.As(err, &storeErr) && storeErr.Code != "" {
+		return storeErr.Code
+	}
+
+	return errorCodeInternal
+}
+
+func stringOrEmpty(value *string) string {
+	if value == nil {
+		return ""
+	}
+
+	return *value
+}
+
+func int64OrZero(value *int64) int64 {
+	if value == nil {
+		return 0
+	}
+
+	return *value
+}

--- a/internal/plugins/sql/plugin.go
+++ b/internal/plugins/sql/plugin.go
@@ -444,6 +444,7 @@ func (p *Plugin) initializeSchema(ctx context.Context) error {
 func (p *Plugin) applyExternalMigrations(ctx context.Context) error {
 	migrationFiles := []string{
 		"scripts/sql/032_user_state_foundation.sql",
+		"scripts/sql/033_economy_api.sql",
 	}
 
 	for _, migrationFile := range migrationFiles {

--- a/scripts/sql/033_economy_api.sql
+++ b/scripts/sql/033_economy_api.sql
@@ -1,0 +1,514 @@
+CREATE TABLE IF NOT EXISTS daz_economy_ledger (
+    id BIGSERIAL PRIMARY KEY,
+    channel VARCHAR(255) NOT NULL,
+    kind VARCHAR(16) NOT NULL CHECK (kind IN ('credit', 'debit', 'transfer')),
+    actor VARCHAR(255),
+    from_username VARCHAR(255),
+    to_username VARCHAR(255),
+    amount BIGINT NOT NULL CHECK (amount > 0),
+    reason TEXT,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    idempotency_key VARCHAR(255),
+    balance_after BIGINT,
+    from_balance_after BIGINT,
+    to_balance_after BIGINT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_economy_ledger_channel_created_at
+    ON daz_economy_ledger(channel, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_economy_ledger_channel_from_username
+    ON daz_economy_ledger(channel, from_username, created_at DESC)
+    WHERE from_username IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_economy_ledger_channel_to_username
+    ON daz_economy_ledger(channel, to_username, created_at DESC)
+    WHERE to_username IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_economy_ledger_channel_idempotency
+    ON daz_economy_ledger(channel, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION daz_economy_get_balance(
+    p_channel VARCHAR(255),
+    p_username VARCHAR(255)
+) RETURNS TABLE (
+    ok BOOLEAN,
+    error_code TEXT,
+    balance BIGINT
+) AS $$
+DECLARE
+    v_channel VARCHAR(255);
+    v_username VARCHAR(255);
+BEGIN
+    v_channel := TRIM(COALESCE(p_channel, ''));
+    v_username := LOWER(TRIM(COALESCE(p_username, '')));
+
+    IF v_channel = '' THEN
+        RETURN QUERY SELECT FALSE, 'INVALID_ARGUMENT', 0::BIGINT;
+        RETURN;
+    END IF;
+
+    IF v_username = '' THEN
+        RETURN QUERY SELECT FALSE, 'INVALID_ARGUMENT', 0::BIGINT;
+        RETURN;
+    END IF;
+
+    INSERT INTO daz_user_economy (channel, username, balance, total_earned, total_lost)
+    VALUES (v_channel, v_username, 0, 0, 0)
+    ON CONFLICT (channel, username) DO NOTHING;
+
+    RETURN QUERY
+    SELECT TRUE, NULL::TEXT, ue.balance
+    FROM daz_user_economy ue
+    WHERE ue.channel = v_channel
+      AND ue.username = v_username;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION daz_economy_credit(
+    p_channel VARCHAR(255),
+    p_username VARCHAR(255),
+    p_amount BIGINT,
+    p_idempotency_key VARCHAR(255),
+    p_actor VARCHAR(255),
+    p_reason TEXT,
+    p_metadata JSONB
+) RETURNS TABLE (
+    ok BOOLEAN,
+    error_code TEXT,
+    balance BIGINT,
+    ledger_id BIGINT,
+    already_applied BOOLEAN
+) AS $$
+DECLARE
+    v_channel VARCHAR(255);
+    v_username VARCHAR(255);
+    v_key VARCHAR(255);
+    v_actor VARCHAR(255);
+    v_reason TEXT;
+    v_metadata JSONB;
+    v_balance BIGINT;
+    v_ledger_id BIGINT;
+    v_existing RECORD;
+BEGIN
+    v_channel := TRIM(COALESCE(p_channel, ''));
+    v_username := LOWER(TRIM(COALESCE(p_username, '')));
+    v_key := NULLIF(TRIM(COALESCE(p_idempotency_key, '')), '');
+    v_actor := NULLIF(TRIM(COALESCE(p_actor, '')), '');
+    v_reason := NULLIF(TRIM(COALESCE(p_reason, '')), '');
+    v_metadata := COALESCE(p_metadata, '{}'::jsonb);
+
+    IF v_channel = '' THEN
+        RETURN QUERY SELECT FALSE, 'INVALID_ARGUMENT', 0::BIGINT, NULL::BIGINT, FALSE;
+        RETURN;
+    END IF;
+
+    IF v_username = '' THEN
+        RETURN QUERY SELECT FALSE, 'INVALID_ARGUMENT', 0::BIGINT, NULL::BIGINT, FALSE;
+        RETURN;
+    END IF;
+
+    IF p_amount IS NULL OR p_amount <= 0 THEN
+        RETURN QUERY SELECT FALSE, 'INVALID_AMOUNT', 0::BIGINT, NULL::BIGINT, FALSE;
+        RETURN;
+    END IF;
+
+    IF v_key IS NOT NULL THEN
+        PERFORM pg_advisory_xact_lock(hashtextextended(v_channel || ':' || v_key, 0));
+
+        SELECT l.id,
+               l.kind,
+               l.actor,
+               l.from_username,
+               l.to_username,
+               l.amount,
+               l.reason,
+               l.metadata,
+               l.balance_after
+        INTO v_existing
+        FROM daz_economy_ledger l
+        WHERE l.channel = v_channel
+          AND l.idempotency_key = v_key
+        LIMIT 1;
+
+        IF FOUND THEN
+            IF v_existing.kind = 'credit'
+               AND v_existing.to_username = v_username
+               AND v_existing.amount = p_amount
+               AND COALESCE(v_existing.actor, '') = COALESCE(v_actor, '')
+               AND COALESCE(v_existing.reason, '') = COALESCE(v_reason, '')
+               AND COALESCE(v_existing.metadata, '{}'::jsonb) = v_metadata THEN
+                RETURN QUERY
+                SELECT TRUE, NULL::TEXT, v_existing.balance_after, v_existing.id, TRUE;
+                RETURN;
+            END IF;
+
+            RETURN QUERY SELECT FALSE, 'IDEMPOTENCY_CONFLICT', 0::BIGINT, NULL::BIGINT, FALSE;
+            RETURN;
+        END IF;
+    END IF;
+
+    INSERT INTO daz_user_economy (channel, username, balance, total_earned, total_lost)
+    VALUES (v_channel, v_username, 0, 0, 0)
+    ON CONFLICT (channel, username) DO NOTHING;
+
+    PERFORM 1
+    FROM daz_user_economy ue
+    WHERE ue.channel = v_channel
+      AND ue.username = v_username
+    FOR UPDATE;
+
+    UPDATE daz_user_economy ue
+    SET balance = ue.balance + p_amount,
+        total_earned = ue.total_earned + p_amount,
+        updated_at = NOW()
+    WHERE ue.channel = v_channel
+      AND ue.username = v_username
+    RETURNING ue.balance INTO v_balance;
+
+    INSERT INTO daz_economy_ledger (
+        channel,
+        kind,
+        actor,
+        to_username,
+        amount,
+        reason,
+        metadata,
+        idempotency_key,
+        balance_after
+    ) VALUES (
+        v_channel,
+        'credit',
+        v_actor,
+        v_username,
+        p_amount,
+        v_reason,
+        v_metadata,
+        v_key,
+        v_balance
+    )
+    RETURNING id INTO v_ledger_id;
+
+    RETURN QUERY SELECT TRUE, NULL::TEXT, v_balance, v_ledger_id, FALSE;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION daz_economy_debit(
+    p_channel VARCHAR(255),
+    p_username VARCHAR(255),
+    p_amount BIGINT,
+    p_idempotency_key VARCHAR(255),
+    p_actor VARCHAR(255),
+    p_reason TEXT,
+    p_metadata JSONB
+) RETURNS TABLE (
+    ok BOOLEAN,
+    error_code TEXT,
+    balance BIGINT,
+    ledger_id BIGINT,
+    already_applied BOOLEAN
+) AS $$
+DECLARE
+    v_channel VARCHAR(255);
+    v_username VARCHAR(255);
+    v_key VARCHAR(255);
+    v_actor VARCHAR(255);
+    v_reason TEXT;
+    v_metadata JSONB;
+    v_current_balance BIGINT;
+    v_balance BIGINT;
+    v_ledger_id BIGINT;
+    v_existing RECORD;
+BEGIN
+    v_channel := TRIM(COALESCE(p_channel, ''));
+    v_username := LOWER(TRIM(COALESCE(p_username, '')));
+    v_key := NULLIF(TRIM(COALESCE(p_idempotency_key, '')), '');
+    v_actor := NULLIF(TRIM(COALESCE(p_actor, '')), '');
+    v_reason := NULLIF(TRIM(COALESCE(p_reason, '')), '');
+    v_metadata := COALESCE(p_metadata, '{}'::jsonb);
+
+    IF v_channel = '' THEN
+        RETURN QUERY SELECT FALSE, 'INVALID_ARGUMENT', 0::BIGINT, NULL::BIGINT, FALSE;
+        RETURN;
+    END IF;
+
+    IF v_username = '' THEN
+        RETURN QUERY SELECT FALSE, 'INVALID_ARGUMENT', 0::BIGINT, NULL::BIGINT, FALSE;
+        RETURN;
+    END IF;
+
+    IF p_amount IS NULL OR p_amount <= 0 THEN
+        RETURN QUERY SELECT FALSE, 'INVALID_AMOUNT', 0::BIGINT, NULL::BIGINT, FALSE;
+        RETURN;
+    END IF;
+
+    IF v_key IS NOT NULL THEN
+        PERFORM pg_advisory_xact_lock(hashtextextended(v_channel || ':' || v_key, 0));
+
+        SELECT l.id,
+               l.kind,
+               l.actor,
+               l.from_username,
+               l.to_username,
+               l.amount,
+               l.reason,
+               l.metadata,
+               l.balance_after
+        INTO v_existing
+        FROM daz_economy_ledger l
+        WHERE l.channel = v_channel
+          AND l.idempotency_key = v_key
+        LIMIT 1;
+
+        IF FOUND THEN
+            IF v_existing.kind = 'debit'
+               AND v_existing.from_username = v_username
+               AND v_existing.amount = p_amount
+               AND COALESCE(v_existing.actor, '') = COALESCE(v_actor, '')
+               AND COALESCE(v_existing.reason, '') = COALESCE(v_reason, '')
+               AND COALESCE(v_existing.metadata, '{}'::jsonb) = v_metadata THEN
+                RETURN QUERY
+                SELECT TRUE, NULL::TEXT, v_existing.balance_after, v_existing.id, TRUE;
+                RETURN;
+            END IF;
+
+            RETURN QUERY SELECT FALSE, 'IDEMPOTENCY_CONFLICT', 0::BIGINT, NULL::BIGINT, FALSE;
+            RETURN;
+        END IF;
+    END IF;
+
+    INSERT INTO daz_user_economy (channel, username, balance, total_earned, total_lost)
+    VALUES (v_channel, v_username, 0, 0, 0)
+    ON CONFLICT (channel, username) DO NOTHING;
+
+    SELECT ue.balance
+    INTO v_current_balance
+    FROM daz_user_economy ue
+    WHERE ue.channel = v_channel
+      AND ue.username = v_username
+    FOR UPDATE;
+
+    IF v_current_balance < p_amount THEN
+        RETURN QUERY SELECT FALSE, 'INSUFFICIENT_FUNDS', v_current_balance, NULL::BIGINT, FALSE;
+        RETURN;
+    END IF;
+
+    UPDATE daz_user_economy ue
+    SET balance = ue.balance - p_amount,
+        total_lost = ue.total_lost + p_amount,
+        updated_at = NOW()
+    WHERE ue.channel = v_channel
+      AND ue.username = v_username
+    RETURNING ue.balance INTO v_balance;
+
+    INSERT INTO daz_economy_ledger (
+        channel,
+        kind,
+        actor,
+        from_username,
+        amount,
+        reason,
+        metadata,
+        idempotency_key,
+        balance_after
+    ) VALUES (
+        v_channel,
+        'debit',
+        v_actor,
+        v_username,
+        p_amount,
+        v_reason,
+        v_metadata,
+        v_key,
+        v_balance
+    )
+    RETURNING id INTO v_ledger_id;
+
+    RETURN QUERY SELECT TRUE, NULL::TEXT, v_balance, v_ledger_id, FALSE;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION daz_economy_transfer(
+    p_channel VARCHAR(255),
+    p_from_username VARCHAR(255),
+    p_to_username VARCHAR(255),
+    p_amount BIGINT,
+    p_idempotency_key VARCHAR(255),
+    p_actor VARCHAR(255),
+    p_reason TEXT,
+    p_metadata JSONB
+) RETURNS TABLE (
+    ok BOOLEAN,
+    error_code TEXT,
+    from_balance BIGINT,
+    to_balance BIGINT,
+    ledger_id BIGINT,
+    already_applied BOOLEAN
+) AS $$
+DECLARE
+    v_channel VARCHAR(255);
+    v_from_username VARCHAR(255);
+    v_to_username VARCHAR(255);
+    v_first_username VARCHAR(255);
+    v_second_username VARCHAR(255);
+    v_key VARCHAR(255);
+    v_actor VARCHAR(255);
+    v_reason TEXT;
+    v_metadata JSONB;
+    v_from_current BIGINT;
+    v_from_balance BIGINT;
+    v_to_balance BIGINT;
+    v_ledger_id BIGINT;
+    v_existing RECORD;
+BEGIN
+    v_channel := TRIM(COALESCE(p_channel, ''));
+    v_from_username := LOWER(TRIM(COALESCE(p_from_username, '')));
+    v_to_username := LOWER(TRIM(COALESCE(p_to_username, '')));
+    v_key := NULLIF(TRIM(COALESCE(p_idempotency_key, '')), '');
+    v_actor := NULLIF(TRIM(COALESCE(p_actor, '')), '');
+    v_reason := NULLIF(TRIM(COALESCE(p_reason, '')), '');
+    v_metadata := COALESCE(p_metadata, '{}'::jsonb);
+
+    IF v_channel = '' THEN
+        RETURN QUERY SELECT FALSE, 'INVALID_ARGUMENT', 0::BIGINT, 0::BIGINT, NULL::BIGINT, FALSE;
+        RETURN;
+    END IF;
+
+    IF v_from_username = '' OR v_to_username = '' THEN
+        RETURN QUERY SELECT FALSE, 'INVALID_ARGUMENT', 0::BIGINT, 0::BIGINT, NULL::BIGINT, FALSE;
+        RETURN;
+    END IF;
+
+    IF v_from_username = v_to_username THEN
+        RETURN QUERY SELECT FALSE, 'INVALID_ARGUMENT', 0::BIGINT, 0::BIGINT, NULL::BIGINT, FALSE;
+        RETURN;
+    END IF;
+
+    IF p_amount IS NULL OR p_amount <= 0 THEN
+        RETURN QUERY SELECT FALSE, 'INVALID_AMOUNT', 0::BIGINT, 0::BIGINT, NULL::BIGINT, FALSE;
+        RETURN;
+    END IF;
+
+    IF v_key IS NOT NULL THEN
+        PERFORM pg_advisory_xact_lock(hashtextextended(v_channel || ':' || v_key, 0));
+
+        SELECT l.id,
+               l.kind,
+               l.actor,
+               l.from_username,
+               l.to_username,
+               l.amount,
+               l.reason,
+               l.metadata,
+               l.from_balance_after,
+               l.to_balance_after
+        INTO v_existing
+        FROM daz_economy_ledger l
+        WHERE l.channel = v_channel
+          AND l.idempotency_key = v_key
+        LIMIT 1;
+
+        IF FOUND THEN
+            IF v_existing.kind = 'transfer'
+               AND v_existing.from_username = v_from_username
+               AND v_existing.to_username = v_to_username
+               AND v_existing.amount = p_amount
+               AND COALESCE(v_existing.actor, '') = COALESCE(v_actor, '')
+               AND COALESCE(v_existing.reason, '') = COALESCE(v_reason, '')
+               AND COALESCE(v_existing.metadata, '{}'::jsonb) = v_metadata THEN
+                RETURN QUERY
+                SELECT TRUE, NULL::TEXT, v_existing.from_balance_after, v_existing.to_balance_after, v_existing.id, TRUE;
+                RETURN;
+            END IF;
+
+            RETURN QUERY SELECT FALSE, 'IDEMPOTENCY_CONFLICT', 0::BIGINT, 0::BIGINT, NULL::BIGINT, FALSE;
+            RETURN;
+        END IF;
+    END IF;
+
+    INSERT INTO daz_user_economy (channel, username, balance, total_earned, total_lost)
+    VALUES (v_channel, v_from_username, 0, 0, 0)
+    ON CONFLICT (channel, username) DO NOTHING;
+
+    INSERT INTO daz_user_economy (channel, username, balance, total_earned, total_lost)
+    VALUES (v_channel, v_to_username, 0, 0, 0)
+    ON CONFLICT (channel, username) DO NOTHING;
+
+    v_first_username := LEAST(v_from_username, v_to_username);
+    v_second_username := GREATEST(v_from_username, v_to_username);
+
+    PERFORM 1
+    FROM daz_user_economy ue
+    WHERE ue.channel = v_channel
+      AND ue.username = v_first_username
+    FOR UPDATE;
+
+    PERFORM 1
+    FROM daz_user_economy ue
+    WHERE ue.channel = v_channel
+      AND ue.username = v_second_username
+    FOR UPDATE;
+
+    SELECT ue.balance
+    INTO v_from_current
+    FROM daz_user_economy ue
+    WHERE ue.channel = v_channel
+      AND ue.username = v_from_username;
+
+    IF v_from_current < p_amount THEN
+        RETURN QUERY SELECT FALSE, 'INSUFFICIENT_FUNDS', v_from_current, 0::BIGINT, NULL::BIGINT, FALSE;
+        RETURN;
+    END IF;
+
+    UPDATE daz_user_economy ue
+    SET balance = ue.balance - p_amount,
+        total_lost = ue.total_lost + p_amount,
+        updated_at = NOW()
+    WHERE ue.channel = v_channel
+      AND ue.username = v_from_username
+    RETURNING ue.balance INTO v_from_balance;
+
+    UPDATE daz_user_economy ue
+    SET balance = ue.balance + p_amount,
+        total_earned = ue.total_earned + p_amount,
+        updated_at = NOW()
+    WHERE ue.channel = v_channel
+      AND ue.username = v_to_username
+    RETURNING ue.balance INTO v_to_balance;
+
+    INSERT INTO daz_economy_ledger (
+        channel,
+        kind,
+        actor,
+        from_username,
+        to_username,
+        amount,
+        reason,
+        metadata,
+        idempotency_key,
+        from_balance_after,
+        to_balance_after
+    ) VALUES (
+        v_channel,
+        'transfer',
+        v_actor,
+        v_from_username,
+        v_to_username,
+        p_amount,
+        v_reason,
+        v_metadata,
+        v_key,
+        v_from_balance,
+        v_to_balance
+    )
+    RETURNING id INTO v_ledger_id;
+
+    RETURN QUERY SELECT TRUE, NULL::TEXT, v_from_balance, v_to_balance, v_ledger_id, FALSE;
+END;
+$$ LANGUAGE plpgsql;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON daz_economy_ledger TO daz_user;
+GRANT USAGE ON SEQUENCE daz_economy_ledger_id_seq TO daz_user;
+GRANT EXECUTE ON FUNCTION daz_economy_get_balance(VARCHAR, VARCHAR) TO daz_user;
+GRANT EXECUTE ON FUNCTION daz_economy_credit(VARCHAR, VARCHAR, BIGINT, VARCHAR, VARCHAR, TEXT, JSONB) TO daz_user;
+GRANT EXECUTE ON FUNCTION daz_economy_debit(VARCHAR, VARCHAR, BIGINT, VARCHAR, VARCHAR, TEXT, JSONB) TO daz_user;
+GRANT EXECUTE ON FUNCTION daz_economy_transfer(VARCHAR, VARCHAR, VARCHAR, BIGINT, VARCHAR, VARCHAR, TEXT, JSONB) TO daz_user;


### PR DESCRIPTION
## Summary
Implement the Economy API via an EventBus request/reply plugin and a SQL-backed ledger. This change provides a centralized way for plugins to manage per-channel user balances with built-in idempotency and correlation.

### Key Features
- **Centralized Ledger**: SQL-backed storage (`daz_economy_ledger`) for credits, debits, and transfers.
- **Idempotency**: All mutations are idempotent per `(channel, idempotency_key)`, preventing duplicate transactions during retries.
- **Correlation**: Uses `PluginRequest.ID` for correlation between requests and responses.
- **Go Client Wrapper**: `internal/framework/economy_client.go` provides a clean API for other plugins to interact with the economy system.
- **Plugin Integration**: Wired into the main application with configuration support in `config.json.example`.

### Areas Touched
- **Migrations**: Added `scripts/sql/033_economy_api.sql` for the database schema and functions.
- **Framework**: Added `EconomyClient` for standardized API access.
- **Plugins**: New `economy` plugin for handling requests and interacting with the SQL store.
- **Documentation**: Detailed contract documentation in `docs/economy.md` and a development guide in `AGENTS.md`.

### Testing
- **Unit Tests**: `go test ./internal/plugins/economy -count=1`
- **Integration Tests**: Requires PostgreSQL. Run with:
  ```bash
  export DAZ_DB_HOST=localhost DAZ_DB_PORT=5432 DAZ_DB_NAME=daz DAZ_DB_USER=daz DAZ_DB_PASSWORD=daz
  go test -tags=integration ./internal/plugins/economy -count=1
  ```

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)
Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>